### PR TITLE
Setup Dockunit for more comprehensive continuous integration tests

### DIFF
--- a/Dockunit.json
+++ b/Dockunit.json
@@ -1,0 +1,44 @@
+{
+  "containers": [
+    {
+      "prettyName": "nodejs latest",
+      "image": "node:latest",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install",
+        "npm run lint",
+        "npm run dist"
+      ]
+    },
+    {
+      "prettyName": "nodejs 5.0.0",
+      "image": "node:5.0.0",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install",
+        "npm run lint",
+        "npm run dist"
+      ]
+    },
+    {
+      "prettyName": "nodejs 4.2.2",
+      "image": "node:4.2.2",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install",
+        "npm run lint",
+        "npm run dist"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.12.7",
+      "image": "node:0.12.7",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install",
+        "npm run lint",
+        "npm run dist"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[Dockunit](https://dockunit.io) is a continuous integration service built to be container based. It is super helpful because you can build and distribute your test environments from scratch and run tests locally with ease.

This PR tests the client in Node.js latest, 5.0.0, 4.2.1, and 0.12.7. The versions available on Dockunit are much more extensive than that of Travis CI. Incorporating Dockunit now will make it easier to test more complex environments in the future since it is Docker container based.

Assuming the PR is accepted, I'll send another with the Dockunit status badge for the README.md. You can see the [current Dockunit status of the client here](https://dockunit.io/projects/tlovett1/tus-js-client).