### PR TITLE
Use rawgit CDN for jasmine dependencies

### DIFF
--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -18,7 +18,7 @@
   <!-- The JSReporter will allow SauceLabs to automatically extract the tests'
   result, evaluate them and present them in their dashboard, see
   https://wiki.saucelabs.com/display/DOCS/Reporting+JavaScript+Unit+Test+Results+to+Sauce+Labs+Using+Jasmine -->
-  <script src="http://rawgit.com/detro/jasmine-jsreporter/master/jasmine-jsreporter.js"></script>
+  <script src="https://cdn.rawgit.com/detro/jasmine-jsreporter/master/jasmine-jsreporter.js"></script>
   <script>jasmine.getEnv().addReporter(new jasmine.JSReporter2())</script>
 
   <!-- include source files here... -->

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -5,15 +5,15 @@
   <meta charset="utf-8">
   <title>Jasmine Spec Runner</title>
 
-  <link href="../node_modules/jasmine-core/images/jasmine_favicon.png" rel="shortcut icon" type="image/png">
-  <link href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css" rel="stylesheet">
+  <link href="https://cdn.rawgit.com/jasmine/jasmine/master/images/jasmine_favicon.png" rel="shortcut icon" type="image/png">
+  <link href="https://cdn.rawgit.com/jasmine/jasmine/master/lib/jasmine-core/jasmine.css" rel="stylesheet">
 
-  <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
-  <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
-  <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
+  <script src="https://cdn.rawgit.com/jasmine/jasmine/master/lib/jasmine-core/jasmine.js"></script>
+  <script src="https://cdn.rawgit.com/jasmine/jasmine/master/lib/jasmine-core/jasmine-html.js"></script>
+  <script src="https://cdn.rawgit.com/jasmine/jasmine/master/lib/jasmine-core/boot.js"></script>
   <script>window.jasmine.getJSReport=function(){return null}</script>
-  <script src="../node_modules/jasmine-core/lib/console/console.js"></script>
-  <script src="../node_modules/jasmine-ajax/lib/mock-ajax.js"></script>
+  <script src="https://cdn.rawgit.com/jasmine/jasmine/master/lib/console/console.js"></script>
+  <script src="https://cdn.rawgit.com/jasmine/jasmine-ajax/master/lib/mock-ajax.js"></script>
 
   <!-- The JSReporter will allow SauceLabs to automatically extract the tests'
   result, evaluate them and present them in their dashboard, see


### PR DESCRIPTION
Currently, browsing https://rawgit.com/tus/tus-js-client/master/test/SpecRunner.html (as advertised in the README) simply fails because jasmine is inserted via `../node_modules`:
```
https://rawgit.com/tus/tus-js-client/master/node_modules/jasmine-core/lib/jasmine-core/jasmine.css
Failed to load resource: the server responded with a status of 404 ()
```

This PR fixes this by using the rawgit urls for the jasmine dependencies.

**I don't know if this can break SauceLabs tests ?**