### PR TITLE
remove obsolete `babel` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "homepage": "https://github.com/tus/tus-js-client",
   "devDependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.6.5",
     "babel-eslint": "^4.1.5",
     "babel-preset-es2015": "^6.1.18",


### PR DESCRIPTION
`babel` no longer does anything since Babel v6.

npm was installing the `babel` executable stub from the `babel` package instead of the compiler executable from the `babel-cli` package for me, so `npm run transpile` would fail. This removes the obsolete dependency so the `babel-cli` version will always be installed instead.