### PR TITLE
fix buffer initialization in base64 encoding in node

### DIFF
--- a/lib/node/base64.js
+++ b/lib/node/base64.js
@@ -1,4 +1,4 @@
-import bufferFrom from 'buffer-from';
+import bufferFrom from "buffer-from";
 
 export function encode(data) {
   return bufferFrom(String(data)).toString("base64");

--- a/lib/node/base64.js
+++ b/lib/node/base64.js
@@ -1,7 +1,7 @@
-/* global: Buffer */
+import bufferFrom from 'buffer-from';
 
 export function encode(data) {
-  return new Buffer(data).toString("base64");
+  return bufferFrom(String(data)).toString("base64");
 }
 
 export const isSupported = true;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "watchify": "^3.5.0"
   },
   "dependencies": {
+    "buffer-from": "^0.1.1",
     "extend": "^3.0.0",
     "lodash.throttle": "^4.1.1",
     "resolve-url": "^0.2.1"


### PR DESCRIPTION
If a number was passed to `encode()`, the buffer would be created with
uninitialised memory. This patch casts anything that's passed in to
a string first and then uses the safe `Buffer.from` API. `Buffer.from`
was added in Node v4 but the `buffer-from` module ponyfills it for older
Node versions.

See [nodejs/node#4660](https://github.com/nodejs/node/issues/4660)