### PR TITLE
Emit an initial progress event.

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -466,6 +466,8 @@ class Upload {
     }
 
     xhr.send(this._source.slice(start, end));
+
+    this._emitProgress(this._offset, this._size);
   }
 }
 


### PR DESCRIPTION
This patch emits a progress event as soon as the upload starts. When
resuming, this means you get the current upload offset as soon as
possible. When starting a new upload, this allows you to listen for the
`onProgress` event if you need to get the `upload.url` as soon as
possible, when not using fingerprinting.

Context from Uppy, with its restore functionality:

> When uploading many files, sometimes when you crash/navigate away, some files will have created their tus upload already, but haven't uploaded any bytes yet. So, no progress event has fired and Uppy hasn't stored the uploadUrl yet. When restoring without the uploadUrl, another new tus upload is created, resulting in `ASSEMBLY_SATURATED` errrors from transloadit.