### PR TITLE
Add note about server-imposed chunkSize hardlimits

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ be an Error instance.
 `withCredentials` in all XMLHttpRequests to use Cookies in requests. The
 remote server must accept CORS and credentials.
 * `chunkSize = Infinity`: a number indicating the maximum size of a chunk
-uploaded in a single request
+uploaded in a single request.  Note that if the server has hard limits (such as
+the minimum 5MB chunk size imposed by S3), specifying a chunk size which falls
+outside those hard limits will cause chunked uploads to fail
 * `metadata = {}`: an object with string values used as additional meta data
 which will be passed along to the server when (and only when) creating a new
 upload. Can be used for filenames, file types etc.


### PR DESCRIPTION
Adds a note to the readme to mention that exceeding any server-imposed chunk size hardlimits will result in chunked uploads failing.

This is to help anyone who doesn't realise that they're hitting such limits.  See the following for further information / discussion:
- https://github.com/tus/tus-resumable-upload-protocol/issues/89
- https://github.com/tus/tus-resumable-upload-protocol/pull/93