### PR TITLE
incorrect mix import and module.exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,7 @@ if (typeof window !== "undefined") {
   var isSupported = true;
 }
 
-// The usage of the commonjs exporting syntax instead of the new ECMAScript
-// one is actually inteded and prevents weird behaviour if we are trying to
-// import this module in another module using Babel.
-module.exports = {
+export default {
   Upload,
   isSupported,
   canStoreURLs,


### PR DESCRIPTION
It's incorrect to mix these two syntaxes. You have an es5 module, not sure why you would want to even try using modules.export in this file.