### PR TITLE
No need to start upload if filesize is 0

### DIFF
--- a/lib.es5/upload.js
+++ b/lib.es5/upload.js
@@ -350,6 +350,13 @@ var Upload = function () {
 
         _this2.url = (0, _request.resolveUrl)(_this2.options.endpoint, location);
 
+        if (_this2._size === 0) {
+          // Nothing to upload and file was successfully created
+          _this2._emitSuccess();
+          _this2._source.close();
+          return;
+        }
+
         if (_this2.options.resume) {
           Storage.setItem(_this2._fingerprint, _this2.url);
         }

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -297,6 +297,13 @@ class Upload {
 
       this.url = resolveUrl(this.options.endpoint, location);
 
+      if (this._size === 0) {
+        // Nothing to upload and file was successfully created
+        this._emitSuccess();
+        this._source.close();
+        return;
+      }
+
       if (this.options.resume) {
         Storage.setItem(this._fingerprint, this.url);
       }


### PR DESCRIPTION
fixes https://github.com/tus/tus-js-client/issues/106

This assumes that if `upload_size` equals `0` it will finish the upload after the file was successfully created (server side). No additional `PATCH` request will be fired.