### PR TITLE
Add `files` property to only include the necessary files in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "A pure JavaScript client for the tus resumable upload protocol",
   "main": "lib.es5/index.js",
   "jsnext:main": "lib/index.js",
+   "files": [
+    "lib/**/*",
+    "lib.es5/**/*"
+    "dist/**/*",
+    "demo/**/*",
+    "bin/**/*",
+    "test/**/*"
+  ],
   "browser": {
     "./lib/node/request.js": "./lib/browser/request.js",
     "./lib/node/base64.js": "./lib/browser/base64.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "jsnext:main": "lib/index.js",
    "files": [
     "lib/**/*",
-    "lib.es5/**/*"
+    "lib.es5/**/*",
     "dist/**/*",
     "demo/**/*",
     "bin/**/*",


### PR DESCRIPTION
Otherwise things like `.babelrc` get added, and that causes issues for React Native and others, see https://github.com/tus/tus-js-client/pull/114