### PR TITLE
Use module instead of jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.1",
   "description": "A pure JavaScript client for the tus resumable upload protocol",
   "main": "lib.es5/index.js",
-  "jsnext:main": "lib/index.js",
+  "module": "lib/index.js",
   "files": [
     "lib/**/*",
     "lib.es5/**/*",


### PR DESCRIPTION
jsnext:main has been superseded by pkg.module, which indicates the location of a file with import/export declarations.

https://github.com/jsforum/jsforum/issues/5
