### PR TITLE
Exposing metadata generated on server back to the client.

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -305,6 +305,7 @@ class Upload {
 
   _emitSuccess() {
     if (typeof this.options.onSuccess === "function") {
+      this.file.metadata = decodeMetadata(this._xhr.getResponseHeader('upload-metadata'));
       this.options.onSuccess();
     }
   }
@@ -623,6 +624,23 @@ function encodeMetadata(metadata) {
   }
 
   return encoded.join(",");
+}
+
+/**
+ * Decodes encoded metadata sent from the server in order to update client metadata,
+ * so client can user additional information sent from server.
+ * @param {encodedMetadata} encodedMetadata 
+ */
+function decodeMetadata(encodedMetadata){
+  var decoded={};
+  var keyValuePairs = encodedMetadata.split(",");
+
+  keyValuePairs.forEach(function(value) {
+    var keyValue = value.split(" ");
+    decoded[keyValue[0]]= Base64.decode(keyValue[1]);
+  });
+
+  return decoded;
 }
 
 /**


### PR DESCRIPTION
Hello,

Just proposing a possible solution to the following feature requests, as discussed on:
-  https://github.com/tus/tus-js-client/issues/166
and

- https://github.com/transloadit/uppy/issues/1713

This pull requests, just manage to get the possible metadata the server may have included, during the upload, and exposes it back to the client, so it can be accessible when the upload finishes.

So the information would be accesible on tus-js-client on metadata attribute of the file object.

And in uppy, of course it also would be accesible, in a simple manner just as follows, being retrocompatible and without any need of modication on Uppy code:

```
     uppy.on('upload-success', function(file, upload) {
        console.log("Additional metadata of uploaded file, set by the server: "+file.data.metadata.additionalProperty);
    });
```

Let me know if this kind of solution is valid on your opinion. I'm open to colaborate, and make any modification to the pull request, or solve the problem in another way.

Kind regards.