### PR TITLE
Ignore removeFingerprintOnSuccess when there is no storage available

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -622,14 +622,16 @@ class Upload {
     this._offset = offset;
 
     if (offset == this._size) {
-      if (this.options.removeFingerprintOnSuccess && this.options.resume) {
-        // Remove stored fingerprint and corresponding endpoint. This causes
-        // new upload of the same file must be treated as a different file.
-        this._storage.removeItem(this._fingerprint, (err) => {
-          if (err) {
-            this._emitError(err);
-          }
-        });
+      if (this._hasStorage()) {
+        if (this.options.removeFingerprintOnSuccess && this.options.resume) {
+          // Remove stored fingerprint and corresponding endpoint. This causes
+          // new upload of the same file must be treated as a different file.
+          this._storage.removeItem(this._fingerprint, (err) => {
+            if (err) {
+              this._emitError(err);
+            }
+          });
+        }
       }
 
       // Yay, finally done :)


### PR DESCRIPTION
When removeFingerprintOnSuccess is set to true in React Native I discovered that it was causing a null error when upload finishes because there is no storage present.

This fixes that bug by making sure the storage exists when attempting to remove the fingerprint from storage.