### PR TITLE
bugfix - keep streaming buffer around until upload completes

### DIFF
--- a/lib/browser/source.js
+++ b/lib/browser/source.js
@@ -32,22 +32,16 @@ class StreamSource {
   constructor(reader, chunkSize) {
     this._chunkSize = chunkSize;
     this._buffer = undefined;
-    this._bufferOffset = 0;
     this._reader = reader;
     this._done = false;
   }
 
   slice(start, end, callback) {
-    if (start < this._bufferOffset) {
-      callback(new Error("Requested data is before the reader's current offset"));
-      return;
-    }
-
     return this._readUntilEnoughDataOrDone(start, end, callback);
   }
 
   _readUntilEnoughDataOrDone(start, end, callback) {
-    const hasEnoughData = end <= this._bufferOffset + len(this._buffer);
+    const hasEnoughData = end <= len(this._buffer);
     if (this._done || hasEnoughData) {
       var value = this._getDataFromBuffer(start, end);
       callback(null, value, value == null ? this._done : false);
@@ -69,21 +63,13 @@ class StreamSource {
   }
 
   _getDataFromBuffer(start, end) {
-    // Remove data from buffer before `start`.
-    // Data might be reread from the buffer if an upload fails, so we can only
-    // safely delete data when it comes *before* what is currently being read.
-    if (start > this._bufferOffset) {
-      this._buffer = this._buffer.slice(start - this._bufferOffset);
-      this._bufferOffset = start;
-    }
-    // If the buffer is empty after removing old data, all data has been read.
-    const hasAllDataBeenRead = len(this._buffer) === 0;
+    const chunk = this._buffer.slice(start, end);
+    const hasAllDataBeenRead = len(chunk) === 0;
     if (this._done && hasAllDataBeenRead) {
+      this._buffer = undefined;
       return null;
     }
-    // We already removed data before `start`, so we just return the first
-    // chunk from the buffer.
-    return this._buffer.slice(0, end - start);
+    return chunk;
   }
 
   close() {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -152,7 +152,6 @@ class Upload {
   _start(source) {
     let file = this.file;
 
-
     // First, we look at the uploadLengthDeferred option.
     // Next, we check if the caller has supplied a manual upload size.
     // Finally, we try to use the calculated size from the source object.

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -89,9 +89,7 @@ class Upload {
     const retryIfShould = (err) => {
       if (shouldRetry(err, retryAttempt, options)) {
         const delay = options.retryDelays[retryAttempt++];
-        setTimeout(() => {
-          Upload.terminate(url, options, cb);
-        }, delay);
+        setTimeout(() => Upload.terminate(url, options, cb), delay);
       } else {
         cb(err);
       }

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -89,7 +89,9 @@ class Upload {
     const retryIfShould = (err) => {
       if (shouldRetry(err, retryAttempt, options)) {
         const delay = options.retryDelays[retryAttempt++];
-        setTimeout(() => Upload.terminate(url, options, cb), delay);
+        setTimeout(() => {
+          Upload.terminate(url, options, cb);
+        }, delay);
       } else {
         cb(err);
       }
@@ -151,6 +153,7 @@ class Upload {
 
   _start(source) {
     let file = this.file;
+
 
     // First, we look at the uploadLengthDeferred option.
     // Next, we check if the caller has supplied a manual upload size.


### PR DESCRIPTION
**What's happening now**
When a segment fails to upload _and_ it's deemed retryable, the tus client issues a request to the server asking for the latest byte offset. That offset is then passed to the `source` as the starting position for the next segment of data. This will result in a `Requested data is before the reader's current offset` error. 

**Why is this happening**
The issue is caused by the source deleting data that has already been read. The idea was solid, but there doesn't appear to be a way to verify for sure what data is okay to delete outside of issuing an offset request to the server. Even if we had it, I don't see a clean way to get that info back into the source. 

**How this fixes it**
The solution is to keep the buffer around until the upload is complete. I think the intention was to prevent unbounded buffer growth, but it's okay to keep around for two reasons:

1 - When uploading a normal file, the entire thing is held in a buffer without issue.
2 - Albeit anecdotal, I've tested this with two simultaneous video recordings up to 20 minutes long without issue. 

If we wanted to try and delete data from the buffer periodically, my testing suggests that the retry only goes back a few segments, so we could probably safely delete data 5 or so segments back from the last read. I would like to avoid this however because it makes reading the buffer more complex and stateful. 