### PR TITLE
Remove core-js and provide transpiled ES Module output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
 	"presets": [
-		[ "@babel/preset-env", { "useBuiltIns": "usage", "corejs": 3 } ]
+		[ "@babel/preset-env", {
+			"corejs": false,
+			"forceAllTransforms": true
+		} ]
 	]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
 	"presets": [
 		[ "@babel/preset-env", {
+			"modules": false,
 			"corejs": false,
 			"forceAllTransforms": true
 		} ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 demos/reactnative/.expo
 lib.es5
+lib.esm
 dist
 .DS_Store

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,9 +16,15 @@ After that, you can load the package:
 var tus = require("tus-js-client");
 ```
 
+If your bundler supports ES Modules, you can use:
+
+```js
+import tus from "tus-js-client";
+```
+
 ## Embed using a script tag
 
-If you are not using a web bundler, you can directly embed the prebuilt script directly:
+If you are not using a web bundler, you can embed the prebuilt script directly:
 
 ```html
 <script src="dist/tus.js"></script>
@@ -37,7 +43,14 @@ tus-js-client can be used in following environments:
 
 Please see the following sections for more details on environment-specific requirements and possible limitations.
 
-One general requirements is that the JavaScript environment must support [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises), which is the case for modern browsers and Node.js. However, if your application runs in older browsers or other environments without support for Promises, you can use a Promise polyfill to fill this gap. Have a look at [caniuse.com](https://caniuse.com/#feat=promises) for a list of those browsers and [core-js](https://github.com/zloirock/core-js#ecmascript-promise) for polyfilling.
+One general requirement is that the JavaScript environment must support [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises), which is the case for modern browsers and Node.js. However, if your application runs in older browsers or other environments without support for Promises, you can use a Promise polyfill to fill this gap. Have a look at [caniuse.com](https://caniuse.com/#feat=promises) for a list of those browsers and [core-js](https://github.com/zloirock/core-js#ecmascript-promise) for polyfilling.
+
+When polyfilling, load the polyfill _before_ loading tus-js-client:
+
+```js
+require("core-js/features/promise");
+var tus = require("tus-js-client");
+```
 
 ## Browser support
 
@@ -56,11 +69,11 @@ tus-js-client is tested and known to support following browsers:
 * iOS 6.0+
 * Android 5.0+
 
-Support in other browsers is *very likely* but has not been confirimed yet.
+Support in other browsers is *very likely* but has not been confirmed yet.
 Since we only use Web Storage, XMLHttpRequest2, the File API and Blob API,
 more than 95% of today's users should be able to use tus-js-client.
 
-Compatability between browsers is continuously ensured by automated tests
+Compatibility between browsers is continuously ensured by automated tests
 in the corresponding browsers on [BrowserStack](https://browserstack.com),
 who provide their great service glady for Open Source project for free.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1191,15 +1191,26 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
-      "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.6.tgz",
+      "integrity": "sha512-7H25fSlLcn+iYimmsNe3uK1at79IE6SKW9q0/QeEHTMC9MdOZ+4bA+T1VFB5fgOqBWoqlifXRzYD0JPdmIrgSQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/helper-simple-access": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+          "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+          "dev": true,
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-systemjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3873,11 +3873,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-    },
     "core-js-compat": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "browserify": "^12.0.0",
     "browserstack": "^1.5.2",
     "browserstack-runner": "git://github.com/Acconut/browserstack-runner.git#fix_etxtbsy",
+    "es6-promise": "^4.2.8",
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.11.1",
     "exorcist": "^0.4.0",
@@ -59,7 +60,6 @@
   "dependencies": {
     "buffer-from": "^0.1.1",
     "combine-errors": "^3.0.3",
-    "core-js": "^3.6.5",
     "js-base64": "^2.4.9",
     "lodash.throttle": "^4.1.1",
     "proper-lockfile": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "2.0.0",
   "description": "A pure JavaScript client for the tus resumable upload protocol",
   "main": "lib.es5/node/index.js",
-  "module": "lib/node/index.js",
+  "module": "lib.esm/node/index.js",
   "files": [
     "lib/**/*",
     "lib.es5/**/*",
+    "lib.esm/**/*",
     "dist/**/*",
     "demos/**/*",
     "bin/**/*",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.9.6",
     "@babel/preset-env": "^7.0.0",
     "axios": "^0.18.0",
     "babelify": "^10.0.0",
@@ -66,10 +68,12 @@
     "url-parse": "^1.4.3"
   },
   "scripts": {
-    "build-test-bundle": "mkdir -p dist && browserify test/spec/browser-index.js -t babelify -d -o dist/browser-test-bundle.js",
-    "build-bundle": "mkdir -p dist && browserify lib/browser/index.js -t babelify -s tus -d | exorcist ./dist/tus.js.map > dist/tus.js",
+    "build-test-bundle": "mkdir -p dist && browserify test/spec/browser-index.js -t [ babelify --plugins [ @babel/transform-modules-commonjs ] ] -d -o dist/browser-test-bundle.js",
+    "build-bundle": "mkdir -p dist && browserify lib/browser/index.js -t [ babelify --plugins [ @babel/transform-modules-commonjs ] ] -s tus -d | exorcist ./dist/tus.js.map > dist/tus.js",
     "build-minify": "uglifyjs ./dist/tus.js -o ./dist/tus.min.js --compress --mangle --source-map \"content='./dist/tus.js.map',url='tus.min.js.map'\"",
-    "build-transpile": "babel -d lib.es5/ lib/",
+    "build-transpile-esm": "babel -d lib.esm/ lib/",
+    "build-transpile-cjs": "babel --no-babelrc --plugins @babel/transform-modules-commonjs -d lib.es5/ lib.esm/",
+    "build-transpile": "npm-run-all build-transpile-esm build-transpile-cjs",
     "build": "npm-run-all build-bundle build-minify build-transpile build-test-bundle",
     "watch-bundle": "watchify lib/browser/index.js -t babelify -o dist/tus.js -s tus -v -d",
     "watch-test-bundle": "watchify test/spec/browser-index.js -t babelify -d -o dist/browser-test-bundle.js",

--- a/test/spec/browser-index.js
+++ b/test/spec/browser-index.js
@@ -2,10 +2,8 @@
 // with the async/await keywords. See
 // https://babeljs.io/docs/en/babel-plugin-transform-regenerator
 import "regenerator-runtime/runtime";
-
-// The babel-preset-env will automatically insert polyfills from the
-// corejs library in the tests, depending on what features are used.
-// See the .babelrc for the corresponding configuration.
+// Polyfill `Promise` for Internet Explorer.
+import "es6-promise/auto";
 
 // This is a fun piece of code. Let me tell you the story behind it:
 // Internet Explorer 10 and 11 have a bug where the event handlers

--- a/test/spec/helpers/assertUrlStorage.js
+++ b/test/spec/helpers/assertUrlStorage.js
@@ -8,9 +8,9 @@ module.exports = async function assertUrlStorage(urlStorage) {
   const key2 = await urlStorage.addUpload("fingerprintA", { id: 2 });
   const key3 = await urlStorage.addUpload("fingerprintB", { id: 3 });
 
-  expect(key1.startsWith("tus::fingerprintA::")).toBe(true);
-  expect(key2.startsWith("tus::fingerprintA::")).toBe(true);
-  expect(key3.startsWith("tus::fingerprintB::")).toBe(true);
+  expect(/^tus::fingerprintA::/.test(key1)).toBe(true);
+  expect(/^tus::fingerprintA::/.test(key2)).toBe(true);
+  expect(/^tus::fingerprintB::/.test(key3)).toBe(true);
 
   // Query the just stored uploads individually
   result = await urlStorage.findUploadsByFingerprint("fingerprintA");


### PR DESCRIPTION
This does two things 'restore' size and bundler support to v1.x levels:

## Disable `@babel/preset-env` `"useBuiltIns"`
`useBuiltIns` injects loads of polyfills that are installed into the
environment. core-js polyfills are very thorough, but that sometimes
means that it includes things that are actually totally unnecessary.

For example, tus-js-client@2 shipped with a Symbol polyfill, even though
it doesn't use Symbols anywhere. But transpiled array rest spread syntax uses
`Symbol.iterator`, so preset-env figures that `Symbol` is in use,
and adds the polyfill. This requires core-js to override things like
`Object.getOwnPropertyNames` to exclude polyfilled Symbols, etc, and it
just spirals out of control until you have 50KB of polyfills just for
array spread syntax and Promises :)

The only feature that tus-js-client _actually_ appears to require is
`Promise`, which we can reasonably expect users to polyfill (and is already
documented as a requirement).

## Transpile `package.json` `"module"`
`"module"` and `"main"` are both commonly used by bundlers. To support
the widest range of browsers, they should both be transpiled to ES5.
Now `lib.esm` contains ES5 syntax + ES Modules syntax, so bundlers with
ES Modules support can use it. For the browserify build scripts, we need
to add `@babel/plugin-transform-modules-commonjs` manually via a command
line parameter.

It's possible and not weird to use newer syntax, but best if people opt
in to it, which they can do with a resolve alias.
In webpack for example:

```js
resolve: {
  alias: {
    'tus-js-client': path.join(__dirname, 'node_modules/tus-js-client/lib')
  }
}
```
