### PR TITLE
Added onShouldRetry callback for controlling retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ input.addEventListener("change", function(e) {
         },
         onSuccess: function() {
             console.log("Download %s from %s", upload.file.name, upload.url)
+        },
+        onShouldRetry: function(err, retryAttempt, options) {
+          var status = err.originalResponse ? err.originalResponse.getStatus() : 0;
+          // in case the status if 403, fail directly
+          if (status === 403) {
+            return false;
+          }
+          return true;
         }
     })
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,6 @@ input.addEventListener("change", function(e) {
         },
         onSuccess: function() {
             console.log("Download %s from %s", upload.file.name, upload.url)
-        },
-        onShouldRetry: function(err, retryAttempt, options) {
-          var status = err.originalResponse ? err.originalResponse.getStatus() : 0;
-          // in case the status if 403, fail directly
-          if (status === 403) {
-            return false;
-          }
-          return true;
         }
     })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,29 +83,26 @@ onError: function (err) {
 
 An optional function called once an error appears and before retrying.
 
-When no callback is specified, the retry behavior will be the default one: any status codes of 409, 423
-or any other than 4xx will be treated as a server error and the request will be retried automatically.
+When no callback is specified, the retry behavior will be the default one: any status codes of 409, 423 or any other than 4XX will be treated as a server error and the request will be retried automatically, as long as the browser does not indicate that we are offline.
 
-When a callback is specified, its return value will influence the retry behavior.
+When a callback is specified, its return value will influence the retry behavior: The function must return `true` if the request should be retried, `false` otherwise. The argument will be an `Error` instance with additional information about the involved requests.
 
-The argument will be an Error instance with additional information about the involved requests. For example:
-
-The callback must return `true` if the request should be retried, `false` otherwise.
-
-Please note that the callback will not be called when the maximum number of retry attempts was reached or
-whenever the browser indicates that we are offline.
+Please note that the callback will not be invoked when the maximum number of retry attempts was reached.
 
 ```js
 onShouldRetry: function (err, retryAttempt, options) {
     console.log("Error", err)
     console.log("Request", err.originalRequest)
     console.log("Response", err.originalResponse)
-    var status = err.originalResponse ? err.originalResponse.getStatus() : 0;
-    // in case the status if 403, fail directly
+    
+    var status = err.originalResponse ? err.originalResponse.getStatus() : 0
+    // Do not retry if the status is a 403.
     if (status === 403) {
-      return false;
+      return false
     }
-    return true;
+    
+    // For any other status code, we retry.
+    return true
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ if (!tus.isSupported) {
     alert("This browser does not support uploads. Please use a modern browser instead.")
 }
 ````
- 
+
 ## tus.canStoreURLs
 
 A boolean indicating whether the current environment allows storing URLs enabling the corresponding upload to be resumed (see the `tus.Upload#resumeFromPreviousUpload` method). This value will only yield to `true` if we are in a browser environment which provides access to the
@@ -74,6 +74,38 @@ onError: function (err) {
     console.log("Error", err)
     console.log("Request", err.originalRequest)
     console.log("Response", err.originalResponse)
+}
+```
+
+#### onShouldRetry
+
+*Default value:* `null`
+
+An optional function called once an error appears and before retrying.
+
+When no callback is specified, the retry behavior will be the default one: any status codes of 409, 423
+or any other than 4xx will be treated as a server error and the request will be retried automatically.
+
+When a callback is specified, its return value will influence the retry behavior.
+
+The argument will be an Error instance with additional information about the involved requests. For example:
+
+The callback must return `true` if the request should be retried, `false` otherwise.
+
+Please note that the callback will not be called when the maximum number of retry attempts was reached or
+whenever the browser indicates that we are offline.
+
+```js
+onShouldRetry: function (err, retryAttempt, options) {
+    console.log("Error", err)
+    console.log("Request", err.originalRequest)
+    console.log("Response", err.originalResponse)
+    var status = err.originalResponse ? err.originalResponse.getStatus() : 0;
+    // in case the status if 403, fail directly
+    if (status === 403) {
+      return false;
+    }
+    return true;
 }
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,11 +167,7 @@ upload.start()
 
 ## Example: Overriding the default retry behavior
 
-In some cases it might be desirable to change the condition for which an upload will be retried.
-
-This example shows how to override the default retry behavior with a callback function where we decided
-that if the server returned a 403 status code, it means it's about a permission issue and we want to
-display an error message directly instead of waiting for all the retries.
+In some cases it might be desirable to change the condition for which an upload will be retried. This example shows how to override the default retry behavior with a callback function where no retry will occur after a 403 status code (indicating a permission issue) is received. This will cause the error message to be directly logged instead of the retrys kicking in.
 
 ```js
 input.addEventListener("change", function(e) {
@@ -187,16 +183,18 @@ input.addEventListener("change", function(e) {
             filetype: file.type
         },
         onError: function(error) {
-            // display error message
+            // Display an error message
             console.log("Failed because: " + error)
         },
         onShouldRetry: function(err, retryAttempt, options) {
-          var status = err.originalResponse ? err.originalResponse.getStatus() : 0;
-          // in case the status if 403, fail directly
+          var status = err.originalResponse ? err.originalResponse.getStatus() : 0
+          // If the status is a 403, we do not want to retry.
           if (status === 403) {
-            return false;
+            return false
           }
-          return true;
+          
+          // For any other status code, tus-js-client should retry.
+          return true
         }
     })
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -924,24 +924,19 @@ function shouldRetry(err, retryAttempt, options) {
   // - retryDelays option is set
   // - we didn't exceed the maxium number of retries, yet, and
   // - this error was caused by a request or it's response and
-  // - the error is server error (i.e. no a status 4xx or a 409 or 423) or
+  // - the error is server error (i.e. not a status 4xx except a 409 or 423) or
   // a onShouldRetry is specified and returns true
   // - the browser does not indicate that we are offline
-  let status = err.originalResponse ? err.originalResponse.getStatus() : 0;
+  if (options.retryDelays == null || retryAttempt >= options.retryDelays.length || err.originalRequest == null) {
+    return false;
+  }
 
-  // define as function so we only call it if really needed
-  let doRetry = () => {
-    if (options && typeof options.onShouldRetry === "function") {
-      return options.onShouldRetry(err, retryAttempt, options);
-    } else {
-      return !inStatusCategory(status, 400) || status === 409 || status === 423;
-    }
-  };
-  return options.retryDelays != null &&
-         retryAttempt < options.retryDelays.length &&
-         err.originalRequest != null &&
-         isOnline() &&
-         doRetry();
+  if (options && typeof options.onShouldRetry === "function") {
+    return options.onShouldRetry(err, retryAttempt, options);
+  }
+
+  let status = err.originalResponse ? err.originalResponse.getStatus() : 0;
+  return ( !inStatusCategory(status, 400) || status === 409 || status === 423 ) && isOnline();
 }
 
 /**

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -24,6 +24,7 @@ const defaultOptions = {
   addRequestId: false,
   onBeforeRequest: null,
   onAfterResponse: null,
+  onShouldRetry: null,
 
   chunkSize: Infinity,
   retryDelays: [0, 1000, 3000, 5000],
@@ -923,15 +924,24 @@ function shouldRetry(err, retryAttempt, options) {
   // - retryDelays option is set
   // - we didn't exceed the maxium number of retries, yet, and
   // - this error was caused by a request or it's response and
-  // - the error is server error (i.e. no a status 4xx or a 409 or 423) and
+  // - the error is server error (i.e. no a status 4xx or a 409 or 423) or
+  // a onShouldRetry is specified and returns true
   // - the browser does not indicate that we are offline
   let status = err.originalResponse ? err.originalResponse.getStatus() : 0;
-  let isServerError = !inStatusCategory(status, 400) || status === 409 || status === 423;
+
+  // define as function so we only call it if really needed
+  let doRetry = () => {
+    if (options && typeof options.onShouldRetry === "function") {
+      return options.onShouldRetry(err, retryAttempt, options);
+    } else {
+      return !inStatusCategory(status, 400) || status === 409 || status === 423;
+    }
+  };
   return options.retryDelays != null &&
          retryAttempt < options.retryDelays.length &&
          err.originalRequest != null &&
-         isServerError &&
-         isOnline();
+         isOnline() &&
+         doRetry();
 }
 
 /**

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -850,6 +850,9 @@ describe("tus", function () {
         onShouldRetry: () => true
       };
 
+      spyOn(options, "onShouldRetry").and.callThrough();
+      spyOn(tus.Upload.prototype, "_emitError").and.callThrough();
+
       var upload = new tus.Upload(file, options);
       upload.start();
 
@@ -925,6 +928,12 @@ describe("tus", function () {
 
       await options.onSuccess.toBeCalled;
       expect(options.onSuccess).toHaveBeenCalled();
+
+      let error = upload._emitError.calls.argsFor(0)[0];
+      expect(options.onShouldRetry).toHaveBeenCalled();
+      expect(options.onShouldRetry.calls.argsFor(0)).toEqual([error, 0, upload.options]);
+      error = upload._emitError.calls.argsFor(1)[0];
+      expect(options.onShouldRetry.calls.argsFor(1)).toEqual([error, 1, upload.options]);
     });
 
     // This tests ensures that tus-js-client correctly abort if the

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -838,8 +838,8 @@ describe("tus", function () {
     });
 
     // This tests ensures that tus-js-client correctly retries if the
-    // response of the onShouldRetry is true
-    it("should retry the upload when callback specified and returns true", async function () {
+    // return value of onShouldRetry is true.
+    it("should retry the upload when onShouldRetry specified and returns true", async function () {
       const testStack = new TestHttpStack();
       var file = getBlob("hello world");
       var options = {
@@ -936,8 +936,8 @@ describe("tus", function () {
       expect(options.onShouldRetry.calls.argsFor(1)).toEqual([error, 1, upload.options]);
     });
 
-    // This tests ensures that tus-js-client correctly abort if the
-    // response of the onShouldRetry is false
+    // This tests ensures that tus-js-client correctly aborts if the
+    // return value of onShouldRetry is false.
     it("should not retry the upload when callback specified and returns false", async function () {
       const testStack = new TestHttpStack();
       var file = getBlob("hello world");


### PR DESCRIPTION
Whenever the library is about to retry an upload due to an
error, the new optional callback onShouldRetry will be
called when defined. Its return value will tell the library whether
to actually retry the upload or fail with an error, for example
based on status code checks.

This makes it possible to customize the behavior like reacting on
specific status codes.

Fixes https://github.com/tus/tus-js-client/issues/197