### PR TITLE
 #209 Add onBeforeRequest and onAfterResponse to terminate method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -227,6 +227,18 @@ onBeforeRequest: function (req) {
 }
 ```
 
+You can also return a Promise if you need to perform some calculations before the request is sent:
+
+```js
+onBeforeRequest: function (req) {
+    return new Promise(resolve => {
+        var xhr = req.getUnderlyingObect()
+        xhr.withCredentials = true
+        resolve()
+    })
+}
+```
+
 #### onAfterResponse
 
 *Default value:* `null`
@@ -238,6 +250,19 @@ onAfterResponse: function (req, res) {
     var url = req.getURL()
     var value = res.getHeader("X-My-Header")
     console.log(`Request for ${url} responded with ${value}`)
+}
+```
+
+You can also return a Promise if you need to perform some calculations before tus-js-client processes the response:
+
+```js
+onAfterResponse: function (req, res) {
+    return new Promise(resolve => {
+        var url = req.getURL()
+        var value = res.getHeader("X-My-Header")
+        console.log(`Request for ${url} responded with ${value}`)
+        resolve()
+    })
 }
 ```
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,7 +11,7 @@ export class Upload {
   options: UploadOptions;
   url: string | null;
 
-  static terminate(url: string, options?: UploadOptions, callback?: (error?: Error) => void): void;
+  static terminate(url: string, options?: UploadOptions): Promise<void>;
   start(): void;
   abort(shouldTerminate?: boolean): Promise<void>;
   findPreviousUploads(): Promise<PreviousUpload[]>;

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -834,18 +834,20 @@ class BaseUpload {
    * @api private
    */
   _sendRequest(req, body = null) {
-    if (typeof this.options.onBeforeRequest === "function") {
-      this.options.onBeforeRequest(req);
-    }
+    const onBeforeRequestPromise = (typeof this.options.onBeforeRequest === "function")
+      ? Promise.resolve(this.options.onBeforeRequest(req))
+      : Promise.resolve();
 
-    return req.send(body)
-      .then((res) => {
-        if (typeof this.options.onAfterResponse === "function") {
-          this.options.onAfterResponse(req, res);
-        }
+    return onBeforeRequestPromise.then(() => {
+      return req.send(body)
+        .then((res) => {
+          const onAfterResponsePromise = (typeof this.options.onAfterResponse === "function")
+            ? Promise.resolve(this.options.onAfterResponse(req, res))
+            : Promise.resolve();
 
-        return res;
-      });
+          return onAfterResponsePromise.then(() => res);
+        });
+    });
   }
 }
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -116,17 +116,7 @@ class BaseUpload {
 
     const req = openRequest("DELETE", url, options);
 
-    if (typeof options.onBeforeRequest === "function") {
-      options.onBeforeRequest(req);
-    }
-
-    const promise = req.send();
-
-    return promise.then((res) => {
-      if (typeof options.onAfterResponse === "function") {
-        options.onAfterResponse(req, res);
-      }
-
+    return sendRequest(req, null, options).then((res) => {
       // A 204 response indicates a successfull request
       if (res.getStatus() === 204) {
         return;
@@ -837,26 +827,12 @@ class BaseUpload {
   }
 
   /**
-   * Send a request with the provided body while invoking the onBeforeRequest
-   * and onAfterResponse callbacks.
+   * Send a request with the provided body.
    *
    * @api private
    */
   _sendRequest(req, body = null) {
-    const onBeforeRequestPromise = (typeof this.options.onBeforeRequest === "function")
-      ? Promise.resolve(this.options.onBeforeRequest(req))
-      : Promise.resolve();
-
-    return onBeforeRequestPromise.then(() => {
-      return req.send(body)
-        .then((res) => {
-          const onAfterResponsePromise = (typeof this.options.onAfterResponse === "function")
-            ? Promise.resolve(this.options.onAfterResponse(req, res))
-            : Promise.resolve();
-
-          return onAfterResponsePromise.then(() => res);
-        });
-    });
+    return sendRequest(req, body, this.options);
   }
 }
 
@@ -903,6 +879,29 @@ function openRequest(method, url, options) {
   }
 
   return req;
+}
+
+/**
+ * Send a request with the provided body while invoking the onBeforeRequest
+ * and onAfterResponse callbacks.
+ *
+ * @api private
+ */
+function sendRequest(req, body, options) {
+  const onBeforeRequestPromise = (typeof options.onBeforeRequest === "function")
+    ? Promise.resolve(options.onBeforeRequest(req))
+    : Promise.resolve();
+
+  return onBeforeRequestPromise.then(() => {
+    return req.send(body)
+      .then((res) => {
+        const onAfterResponsePromise = (typeof options.onAfterResponse === "function")
+          ? Promise.resolve(options.onAfterResponse(req, res))
+          : Promise.resolve();
+
+        return onAfterResponsePromise.then(() => res);
+      });
+  });
 }
 
 /**

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -1248,52 +1248,5 @@ describe("tus", function () {
       expect(options.onError).not.toHaveBeenCalled();
       expect(options.onSuccess).toHaveBeenCalled();
     });
-
-    it("should invoke the request and response Promises", async function () {
-      const testStack = new TestHttpStack();
-      var file = getBlob("hello world");
-      var options = {
-        httpStack: testStack,
-        uploadUrl: "http://tus.io/uploads/foo",
-        onBeforeRequest: function (req) {
-          return new Promise(resolve => {
-            expect(req.getURL()).toBe("http://tus.io/uploads/foo");
-            expect(req.getMethod()).toBe("HEAD");
-            resolve();
-          });
-        },
-        onAfterResponse: function (req, res) {
-          return new Promise(resolve => {
-            expect(req.getURL()).toBe("http://tus.io/uploads/foo");
-            expect(req.getMethod()).toBe("HEAD");
-            expect(res.getStatus()).toBe(204);
-            expect(res.getHeader("Upload-Offset")).toBe(11);
-            resolve();
-          });
-        },
-        onSuccess: waitableFunction("onSuccess")
-      };
-      spyOn(options, "onBeforeRequest");
-      spyOn(options, "onAfterResponse");
-
-      var upload = new tus.Upload(file, options);
-      upload.start();
-
-      var req = await testStack.nextRequest();
-      expect(req.url).toBe("http://tus.io/uploads/foo");
-      expect(req.method).toBe("HEAD");
-
-      req.respondWith({
-        status: 204,
-        responseHeaders: {
-          "Upload-Offset": 11,
-          "Upload-Length": 11
-        }
-      });
-
-      await options.onSuccess.toBeCalled;
-      expect(options.onBeforeRequest).toHaveBeenCalled();
-      expect(options.onAfterResponse).toHaveBeenCalled();
-    });
   });
 });


### PR DESCRIPTION
Call onBeforeRequest and onAfterResponse inside the **terminate** method.