### PR TITLE
Safer checking for unsupported callbacks

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -109,9 +109,17 @@ class BaseUpload {
    * @param {object} options Optional options for influencing HTTP requests.
    * @return {Promise} The Promise will be resolved/rejected when the requests finish.
    */
-  static terminate(url, options = {}, cb) {
-    if (typeof options === "function" || typeof cb === "function") {
+  static terminate(url, options) {
+    // Count the number of arguments to see if a callback is being provided as the last
+    // argument in the old style required by tus-js-client 1.x, then throw an error if it is.
+    // `arguments` is a JavaScript built-in variable that contains all of the function's arguments.
+    if (arguments.length > 1 && typeof arguments[arguments.length - 1] === "function") {
       throw new Error("tus: the terminate function does not accept a callback since v2 anymore; please use the returned Promise instead");
+    }
+    // Note that in order for the trick above to work, a default value cannot be set for `options`,
+    // so the check below replaces the old default `{}`.
+    if (options === undefined) {
+      options = {};
     }
 
     const req = openRequest("DELETE", url, options);
@@ -387,8 +395,10 @@ class BaseUpload {
    * @param {boolean} shouldTerminate True if the upload should be deleted from the server.
    * @return {Promise} The Promise will be resolved/rejected when the requests finish.
    */
-  abort(shouldTerminate, cb) {
-    if (typeof cb === "function") {
+  abort(shouldTerminate) {
+    // Count the number of arguments to see if a callback is being provided in the old style required by tus-js-client 1.x, then throw an error if it is.
+    // `arguments` is a JavaScript built-in variable that contains all of the function's arguments.
+    if (arguments.length > 1 && typeof arguments[1] === "function") {
       throw new Error("tus: the abort function does not accept a callback since v2 anymore; please use the returned Promise instead");
     }
 


### PR DESCRIPTION
fixes #222 

This allows implementers to support both tus-js-client 1.x and 2.x, by allowing them to check how many arguments the `abort()` and `terminate()` functions receive.

It will still throw an error if the callback is provided (as the second argument of `abort()` and as the second or third argument of `terminate()`).