### PR TITLE
Add call to findPreviousUploads to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,16 @@ input.addEventListener("change", function(e) {
         }
     })
 
-    // Start the upload
-    upload.start()
+    // Check if there are any previous uploads to continue.
+    upload.findPreviousUploads().then(function (previousUploads) {
+        // Found previous uploads so we select the first one. 
+        if (previousUploads.length) {
+            upload.resumeFromPreviousUpload(previousUploads[0])
+        }
+
+        // Start the upload
+        upload.start()
+    })
 })
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -182,8 +182,16 @@ var upload = new tus.Upload(file, {
     }
 })
 
-// Start the upload by default
-upload.start()
+// Check if there are any previous uploads to continue.
+upload.findPreviousUploads().then(function (previousUploads) {
+    // Found previous uploads so we select the first one. 
+    if (previousUploads.length) {
+        upload.resumeFromPreviousUpload(previousUploads[0])
+    }
+
+    // Start the upload
+    upload.start()
+})
 ```
 
 ## Example: Overriding the default retry behavior
@@ -219,8 +227,16 @@ input.addEventListener("change", function(e) {
         }
     })
 
-    // Start the upload
-    upload.start()
+     // Check if there are any previous uploads to continue.
+    upload.findPreviousUploads().then(function (previousUploads) {
+        // Found previous uploads so we select the first one. 
+        if (previousUploads.length) {
+            upload.resumeFromPreviousUpload(previousUploads[0])
+        }
+
+        // Start the upload
+        upload.start()
+    })
 })
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,8 +47,16 @@ input.addEventListener("change", function(e) {
         }
     })
 
-    // Start the upload
-    upload.start()
+     // Check if there are any previous uploads to continue.
+    upload.findPreviousUploads().then(function (previousUploads) {
+        // Found previous uploads so we select the first one. 
+        if (previousUploads.length) {
+            upload.resumeFromPreviousUpload(previousUploads[0])
+        }
+
+        // Start the upload
+        upload.start()
+    })
 })
 ```
 
@@ -59,6 +67,19 @@ This example shows how you can implement a pauseable upload using tus-js-client.
 ```js
 // Obtain file from user input or similar
 var file = ...
+
+function startOrResumeUpload(upload) {
+    // Check if there are any previous uploads to continue.
+    upload.findPreviousUploads().then(function (previousUploads) {
+        // Found previous uploads so we select the first one. 
+        if (previousUploads.length) {
+            upload.resumeFromPreviousUpload(previousUploads[0])
+        }
+
+        // Start the upload
+        upload.start()
+    })
+}
 
 // Create the tus upload similar to the example from above
 var upload = new tus.Upload(file, {
@@ -80,11 +101,11 @@ pauseButton.addEventListener("click", function() {
 })
 
 unpauseButton.addEventListener("click", function() {
-    upload.start()
+    startOrResumeUpload(upload)
 })
 
 // Start the upload by default
-upload.start()
+startOrResumeUpload(upload)
 ```
 
 ## Example: Let user select upload to resume

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -182,16 +182,8 @@ var upload = new tus.Upload(file, {
     }
 })
 
-// Check if there are any previous uploads to continue.
-upload.findPreviousUploads().then(function (previousUploads) {
-    // Found previous uploads so we select the first one. 
-    if (previousUploads.length) {
-        upload.resumeFromPreviousUpload(previousUploads[0])
-    }
-
-    // Start the upload
-    upload.start()
-})
+// Start the upload
+upload.start()
 ```
 
 ## Example: Overriding the default retry behavior


### PR DESCRIPTION
Seems like the call to `findPreviousUploads` to continue any existing upload is missing from the example so I've added it based on https://github.com/tus/tus-js-client/blob/master/docs/usage.md#example-let-user-select-upload-to-resume