### PR TITLE
Cast options.chunkSize to integer

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -714,7 +714,7 @@ class BaseUpload {
    */
   _addChunkToRequest (req) {
     const start = this._offset
-    let end = this._offset + this.options.chunkSize
+    let end = this._offset + +this.options.chunkSize
 
     req.setProgressHandler((bytesSent) => {
       this._emitProgress(start + bytesSent, this._size)


### PR DESCRIPTION
Hi,

I just had a bug, where I set the `chunkSize` to `"100"`.

Everything was fine on the first chunk, but after that the chunk had a size of `100100` bytes :laughing: 

I have fixed my app to cast the config to an int, but I think that adding this failsafe upstream shouldn't do any harm (and it does not affect `Infinity === +Infinity`)