### PR TITLE
fix #277. Allow typescript to access originalResponse in error case

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -30,8 +30,8 @@ interface UploadOptions {
   onProgress?: ((bytesSent: number, bytesTotal: number) => void) | null;
   onChunkComplete?: ((chunkSize: number, bytesAccepted: number, bytesTotal: number) => void) | null;
   onSuccess?: (() => void) | null;
-  onError?: ((error: DetailedError) => void) | null;
-  onShouldRetry?: ((error: DetailedError, retryAttempt: number, options: UploadOptions) => boolean) | null;
+  onError?: ((error: (Error | DetailedError)) => void) | null;
+  onShouldRetry?: ((error: (Error | DetailedError), retryAttempt: number, options: UploadOptions) => boolean) | null;
 
   overridePatchMethod?: boolean;
   headers?: { [key: string]: string };

--- a/lib/index.test-d.ts
+++ b/lib/index.test-d.ts
@@ -4,6 +4,7 @@
 
 import * as tus from '../';
 import {expectType} from 'tsd';
+import { DetailedError } from '../';
 
 expectType<boolean>(tus.isSupported);
 expectType<boolean>(tus.canStoreURLs);
@@ -26,7 +27,7 @@ const upload = new tus.Upload(file, {
     onSuccess: () => {
     	console.log("Download from %s complete", upload.url);
     },
-    onError: (error: Error) => {
+    onError: (error: (Error | DetailedError)) => {
     	console.log("Failed because: " + error);
     },
     headers: {TestHeader: 'TestValue'},


### PR DESCRIPTION
Built the library with those changes and tried it in my typescript project. Could afterwards successfully access the originalRequest to read and use the sent error message from my backend.