### PR TITLE
Add `parallelUploadBoundaries` option and test

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -42,6 +42,7 @@ interface UploadOptions {
   chunkSize?: number;
   retryDelays?: number[];
   parallelUploads?: number;
+  splitSizeIntoParts?: ((totalSize: number, partCount: number) => { start: number, end: number }[]) | null;
   storeFingerprintForResuming?: boolean;  removeFingerprintOnSuccess?: boolean;
   uploadLengthDeferred?: boolean;
   uploadDataDuringCreation?: boolean;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -42,7 +42,7 @@ interface UploadOptions {
   chunkSize?: number;
   retryDelays?: number[];
   parallelUploads?: number;
-  splitSizeIntoParts?: ((totalSize: number, partCount: number) => { start: number, end: number }[]) | null;
+  parallelUploadBoundaries?: Array<{ start: number; end: number }> | null;
   storeFingerprintForResuming?: boolean;  removeFingerprintOnSuccess?: boolean;
   uploadLengthDeferred?: boolean;
   uploadDataDuringCreation?: boolean;

--- a/lib/index.test-d.ts
+++ b/lib/index.test-d.ts
@@ -38,6 +38,7 @@ const upload = new tus.Upload(file, {
     retryDelays: [10, 20, 50],
     removeFingerprintOnSuccess: true,
     parallelUploads: 42,
+    parallelUploadBoundaries: null,
     onAfterResponse: function (req: tus.HttpRequest, res: tus.HttpResponse) {
 	    var url = req.getURL();
 	    var value = res.getHeader("X-My-Header");

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -29,6 +29,7 @@ const defaultOptions = {
   chunkSize                  : Infinity,
   retryDelays                : [0, 1000, 3000, 5000],
   parallelUploads            : 1,
+  splitSizeIntoParts         : null,
   storeFingerprintForResuming: true,
   removeFingerprintOnSuccess : false,
   uploadLengthDeferred       : false,
@@ -96,6 +97,10 @@ class BaseUpload {
     // An array of BaseUpload instances which are used for uploading the different
     // parts, if the parallelUploads option is used.
     this._parallelUploads = null
+
+    // A custom function for splitting the upload size into parts, if the
+    // parallelUploads option is used.
+    this._splitSizeIntoParts = null
 
     // An array of upload URLs which are used for uploading the different
     // parts, if the parallelUploads option is used.
@@ -196,6 +201,12 @@ class BaseUpload {
       })
     }
 
+    if (this.options.splitSizeIntoParts) {
+      if (this.options.parallelUploads <= 1) {
+          this._emitError(new Error(`tus: cannot use the splitSizeIntoParts option when parallelUploads is disabled`))
+      }
+    }
+
     this.options.fingerprint(file, this.options)
       .then((fingerprint) => {
         if (fingerprint == null) {
@@ -242,7 +253,15 @@ class BaseUpload {
 
     // The input file will be split into multiple slices which are uploaded in separate
     // requests. Here we generate the start and end position for the slices.
-    const parts = splitSizeIntoParts(this._source.size, partCount, this._parallelUploadUrls)
+    const splitSizeFn = this.options.splitSizeIntoParts ?? splitSizeIntoParts;
+    const parts = splitSizeFn(this._source.size, partCount)
+
+  // Attach URLs from previous uploads, if available.
+  if (this._parallelUploadUrls) {
+    parts.forEach((part, index) => {
+      part.uploadUrl = this._parallelUploadUrls[index] || null
+    })
+  }
 
     // Create an empty list for storing the upload URLs
     this._parallelUploadUrls = new Array(parts.length)
@@ -265,6 +284,8 @@ class BaseUpload {
             removeFingerprintOnSuccess : false,
             // Reset the parallelUploads option to not cause recursion.
             parallelUploads            : 1,
+            // Reset splitSizeIntoParts as we are not doing a parallel upload.
+            splitSizeIntoParts         : null,
             metadata                   : {},
             // Add the header to indicate the this is a partial upload.
             headers                    : {
@@ -974,11 +995,10 @@ function resolveUrl (origin, link) {
  *
  * @param {number} totalSize The byte size of the upload, which will be split.
  * @param {number} partCount The number in how many parts the upload will be split.
- * @param {string[]} previousUrls The upload URLs for previous parts.
  * @return {object[]}
  * @api private
  */
-function splitSizeIntoParts (totalSize, partCount, previousUrls) {
+function splitSizeIntoParts (totalSize, partCount) {
   const partSize = Math.floor(totalSize / partCount)
   const parts = []
 
@@ -990,13 +1010,6 @@ function splitSizeIntoParts (totalSize, partCount, previousUrls) {
   }
 
   parts[partCount - 1].end = totalSize
-
-  // Attach URLs from previous uploads, if available.
-  if (previousUrls) {
-    parts.forEach((part, index) => {
-      part.uploadUrl = previousUrls[index] || null
-    })
-  }
 
   return parts
 }

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -193,6 +193,7 @@ class BaseUpload {
       ['uploadUrl', 'uploadSize', 'uploadLengthDeferred'].forEach((optionName) => {
         if (this.options[optionName]) {
           this._emitError(new Error(`tus: cannot use the ${optionName} option when parallelUploads is enabled`))
+          return
         }
       })
     }
@@ -200,9 +201,11 @@ class BaseUpload {
     if (this.options.parallelUploadBoundaries) {
       if (this.options.parallelUploads <= 1) {
         this._emitError(new Error('tus: cannot use the `parallelUploadBoundaries` option when `parallelUploads` is disabled'))
+        return
       }
       if (this.options.parallelUploads !== this.options.parallelUploadBoundaries.length) {
-        this._emitError(new Error('tus: the `parallelUploadBoundaries` must have the same length as the value of `parallelUploads`'));
+        this._emitError(new Error('tus: the `parallelUploadBoundaries` must have the same length as the value of `parallelUploads`'))
+        return
       }
     }
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -29,7 +29,7 @@ const defaultOptions = {
   chunkSize                  : Infinity,
   retryDelays                : [0, 1000, 3000, 5000],
   parallelUploads            : 1,
-  splitSizeIntoParts         : null,
+  parallelUploadBoundaries   : null,
   storeFingerprintForResuming: true,
   removeFingerprintOnSuccess : false,
   uploadLengthDeferred       : false,
@@ -97,10 +97,6 @@ class BaseUpload {
     // An array of BaseUpload instances which are used for uploading the different
     // parts, if the parallelUploads option is used.
     this._parallelUploads = null
-
-    // A custom function for splitting the upload size into parts, if the
-    // parallelUploads option is used.
-    this._splitSizeIntoParts = null
 
     // An array of upload URLs which are used for uploading the different
     // parts, if the parallelUploads option is used.
@@ -201,9 +197,12 @@ class BaseUpload {
       })
     }
 
-    if (this.options.splitSizeIntoParts) {
+    if (this.options.parallelUploadBoundaries) {
       if (this.options.parallelUploads <= 1) {
-          this._emitError(new Error(`tus: cannot use the splitSizeIntoParts option when parallelUploads is disabled`))
+        this._emitError(new Error('tus: cannot use the `parallelUploadBoundaries` option when `parallelUploads` is disabled'))
+      }
+      if (this.options.parallelUploads !== this.options.parallelUploadBoundaries.length) {
+        this._emitError(new Error('tus: the `parallelUploadBoundaries` must have the same length as the value of `parallelUploads`'));
       }
     }
 
@@ -252,16 +251,15 @@ class BaseUpload {
     const partCount = this._parallelUploadUrls != null ? this._parallelUploadUrls.length : this.options.parallelUploads
 
     // The input file will be split into multiple slices which are uploaded in separate
-    // requests. Here we generate the start and end position for the slices.
-    const splitSizeFn = this.options.splitSizeIntoParts ?? splitSizeIntoParts;
-    const parts = splitSizeFn(this._source.size, partCount)
+    // requests. Here we get the start and end position for the slices.
+    const parts = this.options.parallelUploadBoundaries ?? splitSizeIntoParts(this._source.size, partCount)
 
-  // Attach URLs from previous uploads, if available.
-  if (this._parallelUploadUrls) {
-    parts.forEach((part, index) => {
-      part.uploadUrl = this._parallelUploadUrls[index] || null
-    })
-  }
+    // Attach URLs from previous uploads, if available.
+    if (this._parallelUploadUrls) {
+      parts.forEach((part, index) => {
+        part.uploadUrl = this._parallelUploadUrls[index] || null
+      })
+    }
 
     // Create an empty list for storing the upload URLs
     this._parallelUploadUrls = new Array(parts.length)
@@ -284,8 +282,8 @@ class BaseUpload {
             removeFingerprintOnSuccess : false,
             // Reset the parallelUploads option to not cause recursion.
             parallelUploads            : 1,
-            // Reset splitSizeIntoParts as we are not doing a parallel upload.
-            splitSizeIntoParts         : null,
+            // Reset this option as we are not doing a parallel upload.
+            parallelUploadBoundaries   : null,
             metadata                   : {},
             // Add the header to indicate the this is a partial upload.
             headers                    : {

--- a/test/spec/test-parallel-uploads.js
+++ b/test/spec/test-parallel-uploads.js
@@ -13,6 +13,16 @@ describe('tus', () => {
       expect(upload.start.bind(upload)).toThrowError('tus: cannot use the uploadUrl option when parallelUploads is enabled')
     })
 
+    it('should throw if splitSizeIntoParts is passed without parallelUploads', () => {
+      var file = getBlob('hello world')
+      var upload = new tus.Upload(file, {
+        endpoint          : 'https://tus.io/uploads',
+        splitSizeIntoParts: () => {},
+        uploadUrl         : 'foo',
+      })
+      expect(upload.start.bind(upload)).toThrowError('tus: cannot use the splitSizeIntoParts option when parallelUploads is disabled')
+    })
+
     it('should split a file into multiple parts and create an upload for each', async () => {
       const testStack = new TestHttpStack()
 
@@ -174,6 +184,186 @@ describe('tus', () => {
 
       expect(upload.url).toBe('https://tus.io/uploads/upload3')
       expect(options.onProgress).toHaveBeenCalledWith(5, 11)
+      expect(options.onProgress).toHaveBeenCalledWith(11, 11)
+      expect(testUrlStorage.removeUpload).toHaveBeenCalled()
+    })
+
+    it('should split a file into multiple parts based on custom splitSizeIntoParts', async () => {
+      const testStack = new TestHttpStack()
+
+      const testUrlStorage = {
+        addUpload: (fingerprint, upload) => {
+          expect(fingerprint).toBe('fingerprinted')
+          expect(upload.uploadUrl).toBeUndefined()
+          expect(upload.size).toBe(11)
+          expect(upload.parallelUploadUrls).toEqual([
+            'https://tus.io/uploads/upload1',
+            'https://tus.io/uploads/upload2',
+          ])
+
+          return Promise.resolve('tus::fingerprinted::1337')
+        },
+        removeUpload: (urlStorageKey) => {
+          expect(urlStorageKey).toBe('tus::fingerprinted::1337')
+          return Promise.resolve()
+        },
+      }
+      spyOn(testUrlStorage, 'removeUpload').and.callThrough()
+      spyOn(testUrlStorage, 'addUpload').and.callThrough()
+
+      const file = getBlob('hello world')
+      const options = {
+        httpStack                  : testStack,
+        urlStorage                 : testUrlStorage,
+        storeFingerprintForResuming: true,
+        removeFingerprintOnSuccess : true,
+        parallelUploads            : 2,
+        splitSizeIntoParts         : (totalSize, partCount) => {
+          const partSize = 1
+          const parts = []
+
+          for (let i = 0; i < partCount; i++) {
+            parts.push({
+              start: partSize * i,
+              end  : partSize * (i + 1),
+            })
+          }
+
+          parts[partCount - 1].end = totalSize
+
+          return parts
+        },
+        retryDelays                : [10],
+        endpoint                   : 'https://tus.io/uploads',
+        headers                    : {
+          Custom: 'blargh',
+        },
+        metadata: {
+          foo: 'hello',
+        },
+        onProgress () {},
+        onSuccess  : waitableFunction(),
+        fingerprint: () => Promise.resolve('fingerprinted'),
+      }
+      spyOn(options, 'onProgress')
+
+      const upload = new tus.Upload(file, options)
+      upload.start()
+
+      let req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads')
+      expect(req.method).toBe('POST')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Length']).toBe(1)
+      expect(req.requestHeaders['Upload-Concat']).toBe('partial')
+      expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
+
+      req.respondWith({
+        status         : 201,
+        responseHeaders: {
+          Location: 'https://tus.io/uploads/upload1',
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads')
+      expect(req.method).toBe('POST')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Length']).toBe(10)
+      expect(req.requestHeaders['Upload-Concat']).toBe('partial')
+      expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
+
+      req.respondWith({
+        status         : 201,
+        responseHeaders: {
+          Location: 'https://tus.io/uploads/upload2',
+        },
+      })
+
+      req = await testStack.nextRequest()
+
+      // Assert that the URLs have been stored.
+      expect(testUrlStorage.addUpload).toHaveBeenCalled()
+
+      expect(req.url).toBe('https://tus.io/uploads/upload1')
+      expect(req.method).toBe('PATCH')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+      expect(req.body.size).toBe(1)
+
+      req.respondWith({
+        status         : 204,
+        responseHeaders: {
+          'Upload-Offset': 1,
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads/upload2')
+      expect(req.method).toBe('PATCH')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+      expect(req.body.size).toBe(10)
+
+      // Return an error to ensure that the individual partial upload is properly retried.
+      req.respondWith({
+        status: 500,
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads/upload2')
+      expect(req.method).toBe('HEAD')
+
+      req.respondWith({
+        status         : 204,
+        responseHeaders: {
+          'Upload-Length': 11,
+          'Upload-Offset': 0,
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads/upload2')
+      expect(req.method).toBe('PATCH')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+      expect(req.body.size).toBe(10)
+
+      req.respondWith({
+        status         : 204,
+        responseHeaders: {
+          'Upload-Offset': 10,
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads')
+      expect(req.method).toBe('POST')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Length']).toBeUndefined()
+      expect(req.requestHeaders['Upload-Concat']).toBe('final;https://tus.io/uploads/upload1 https://tus.io/uploads/upload2')
+      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
+
+      req.respondWith({
+        status         : 201,
+        responseHeaders: {
+          Location: 'https://tus.io/uploads/upload3',
+        },
+      })
+
+      await options.onSuccess.toBeCalled
+
+      expect(upload.url).toBe('https://tus.io/uploads/upload3')
+      expect(options.onProgress).toHaveBeenCalledWith(1, 11)
       expect(options.onProgress).toHaveBeenCalledWith(11, 11)
       expect(testUrlStorage.removeUpload).toHaveBeenCalled()
     })


### PR DESCRIPTION
# Pull Request

## Overview

Adds `parallelUploadBoundaries` option to customize the size of parallel upload chunks.

## Use Case

In our project we needed to customize the size of the chunks when parallelUploads is used. This is because our backend expects chunks of a certain size.

## Test

Not sure how the devs here test PRs. Here is a simple application that I built on top of the changes:

<snip, will rebuild on request>

## Closes

Closes https://github.com/tus/tus-js-client/issues/298