### PR TITLE
Adds function to store uploadUrl

### DIFF
--- a/demos/browser/index.html
+++ b/demos/browser/index.html
@@ -16,7 +16,7 @@
 
       <p>
         For a prettier demo please go to the
-        <a href="http://tus.io/demo.html">tus.io</a> website.
+        <a href="https://tus.io/demo.html">tus.io</a> website.
         This demo is just here to aid developers.
       </p>
 
@@ -73,7 +73,7 @@
       <div class="row">
         <div class="span8">
           <div class="progress progress-striped progress-success">
-            <div class="bar" style="width: 0%;"></div>
+            <div class="bar" style="width: 0;"></div>
           </div>
         </div>
         <div class="span4">
@@ -84,7 +84,7 @@
       <hr>
       <h3>Uploads</h3>
       <p id="upload-list">
-        Succesful uploads will be listed here. Try one!
+        Successful uploads will be listed here. Try one!
       </p>
 
     </div>

--- a/docs/api.md
+++ b/docs/api.md
@@ -424,7 +424,8 @@ tus.Upload.terminate(url).then(function () {
 
 ## tus.Upload#storeUploadUrlForResume(uploadUrl)
 
-Stores the provided `uploadUrl` to the URL storage using the input file's fingerprint to allow later resume (see `tus.Upload#findPreviousUploads` or `tus.Upload#resumeFromPreviousUpload`). This method can be useful when your tus server automatically creates the upload resources, like when interacting with the Vimeo API.
+Stores the provided `uploadUrl` to the URL storage using the input file's fingerprint to allow later resume (see `tus.Upload#findPreviousUploads` or `tus.Upload#resumeFromPreviousUpload`). This method can be useful when your tus server automatically creates the upload resources, like when interacting with the Vimeo API.<br>
+The function returns a `Promise`, which resolves to the `urlStorageKey` storing the upload metadata object in `localStorage`
 
 ## tus.Upload#findPreviousUploads()
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -64,7 +64,7 @@ class BaseUpload {
     // The underlying request object for the current PATCH request
     this._req = null
 
-    // The fingerpinrt for the current file (set after start())
+    // The fingerprint for the current file (set after start())
     this._fingerprint = null
 
     // The key that the URL storage returned when saving an URL with a fingerprint,
@@ -106,7 +106,7 @@ class BaseUpload {
    * Use the Termination extension to delete an upload from the server by sending a DELETE
    * request to the specified upload URL. This is only possible if the server supports the
    * Termination extension. If the `options.retryDelays` property is set, the method will
-   * also retry if an error ocurrs.
+   * also retry if an error occurs.
    *
    * @param {String} url The upload's URL which will be terminated.
    * @param {object} options Optional options for influencing HTTP requests.
@@ -160,6 +160,29 @@ class BaseUpload {
   findPreviousUploads () {
     return this.options.fingerprint(this.file, this.options)
       .then((fingerprint) => this._urlStorage.findUploadsByFingerprint(fingerprint))
+  }
+
+  storeUploadUrlForResume (uploadUrl) {
+    if (!this.file) {
+      this._emitError(new Error('tus: no file provided'))
+      return
+    }
+
+    const storedUpload = {
+      size        : this._size,
+      metadata    : this.options.metadata,
+      creationTime: new Date().toString(),
+      uploadUrl,
+    }
+
+    this.options.fingerprint(this.file, this.options)
+      .then((fingerprint) => {
+        this._urlStorage.addUpload(fingerprint, storedUpload)
+          .then((urlStorageKey) => {
+            this._urlStorageKey = urlStorageKey
+          })
+          .catch(this._emitError)
+      })
   }
 
   resumeFromPreviousUpload (previousUpload) {
@@ -356,7 +379,7 @@ class BaseUpload {
     } else {
       this._size = this._source.size
       if (this._size == null) {
-        this._emitError(new Error("tus: cannot automatically derive upload's size from input and must be specified manually using the `uploadSize` option"))
+        this._emitError(new Error("tus: cannot automatically derive upload's size from input. Specify it manually using the `uploadSize` option or use the `uploadLengthDeferred` option"))
         return
       }
     }
@@ -375,7 +398,7 @@ class BaseUpload {
 
     // A URL has manually been specified, so we try to resume
     if (this.options.uploadUrl != null) {
-      log(`Resuming upload from provided URL: ${this.options.url}`)
+      log(`Resuming upload from provided URL: ${this.options.uploadUrl}`)
       this.url = this.options.uploadUrl
       this._resumeUpload()
       return

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -164,8 +164,7 @@ class BaseUpload {
 
   storeUploadUrlForResume (uploadUrl) {
     if (!this.file) {
-      this._emitError(new Error('tus: no file provided'))
-      return
+      return this._emitError(new Error('tus: no file provided'))
     }
 
     const storedUpload = {
@@ -175,11 +174,12 @@ class BaseUpload {
       uploadUrl,
     }
 
-    this.options.fingerprint(this.file, this.options)
+    return this.options.fingerprint(this.file, this.options)
       .then((fingerprint) => {
-        this._urlStorage.addUpload(fingerprint, storedUpload)
+        return this._urlStorage.addUpload(fingerprint, storedUpload)
           .then((urlStorageKey) => {
             this._urlStorageKey = urlStorageKey
+            return urlStorageKey
           })
           .catch(this._emitError)
       })


### PR DESCRIPTION
Adds the `storeUploadUrlForResume` public method to store the `uploadUrl`, useful when creating the upload URL from a separate server like Vimeo.
It also adds some details regarding using Vimeo API.

Fixes #200
Fixes #301
Ref #238