### PR TITLE
Export DetailedError from package

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -1,6 +1,7 @@
 import BaseUpload from '../upload'
 import NoopUrlStorage from '../noopUrlStorage'
 import { enableDebugLog } from '../logger'
+import DetailedError from '../error'
 
 import { canStoreURLs, WebStorageUrlStorage } from './urlStorage'
 import HttpStack from './httpStack'
@@ -42,4 +43,5 @@ export {
   isSupported,
   enableDebugLog,
   HttpStack,
+  DetailedError,
 }

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1,6 +1,7 @@
 import BaseUpload from '../upload'
 import NoopUrlStorage from '../noopUrlStorage'
 import { enableDebugLog } from '../logger'
+import DetailedError from '../error'
 
 import { FileUrlStorage, canStoreURLs } from './urlStorage'
 import HttpStack from './httpStack'
@@ -43,4 +44,5 @@ export {
   canStoreURLs,
   enableDebugLog,
   HttpStack,
+  DetailedError,
 }


### PR DESCRIPTION
For example, it's useful for checking in the `shouldRetry` callback:
```js
function onShouldRetry(error) {
  if (error instanceof DetailedError) {
    return doSomethingWithOriginalResponse(error.originalResponse);
  }
}
```

Also this class is already exported, but only in types :) https://github.com/tus/tus-js-client/blob/dc564f143d3eab2b5ddd0848822662ad80606058/lib/index.d.ts#L115