### PR TITLE
fix(node): import promises from fs

### DIFF
--- a/lib/node/sources/FileSource.js
+++ b/lib/node/sources/FileSource.js
@@ -1,8 +1,8 @@
-import { createReadStream, promises } from 'fs'
+import { createReadStream, promises as fsPromises } from 'fs'
 
 export default async function getFileSource (stream) {
   const path = stream.path.toString()
-  const { size } = await promises.stat(path)
+  const { size } = await fsPromises.stat(path)
 
   // The fs.ReadStream might be configured to not read from the beginning
   // to the end, but instead from a slice in between. In this case, we consider

--- a/lib/node/sources/FileSource.js
+++ b/lib/node/sources/FileSource.js
@@ -1,9 +1,8 @@
-import { createReadStream } from 'fs'
-import { stat } from 'fs/promises'
+import { createReadStream, promises } from 'fs'
 
 export default async function getFileSource (stream) {
   const path = stream.path.toString()
-  const { size } = await stat(path)
+  const { size } = await promises.stat(path)
 
   // The fs.ReadStream might be configured to not read from the beginning
   // to the end, but instead from a slice in between. In this case, we consider


### PR DESCRIPTION
Only using the fs import without a subpackage allows webpack to apply the configuration `fs: 'empty'` to promises as well.