### PR TITLE
Prevent potential size overflow and 0 length PATCH

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -738,7 +738,7 @@ class BaseUpload {
     if ((end === Infinity || end > this._size) && !this.options.uploadLengthDeferred) {
       end = this._size
     }
-    
+
     const sliceSize = end - start
     if (sliceSize <= 0) { // done
       req.setHeader('Upload-Length', this._size)

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -738,6 +738,12 @@ class BaseUpload {
     if ((end === Infinity || end > this._size) && !this.options.uploadLengthDeferred) {
       end = this._size
     }
+    
+    const sliceSize = end - start
+    if (sliceSize <= 0) { // done
+      req.setHeader('Upload-Length', this._size)
+      return this._sendRequest(req)
+    }
 
     return this._source.slice(start, end)
       .then(({ value, done }) => {
@@ -775,7 +781,7 @@ class BaseUpload {
 
     this._offset = offset
 
-    if (offset === this._size) {
+    if (offset >= this._size) {
       // Yay, finally done :)
       this._emitSuccess()
       this._source.close()


### PR DESCRIPTION
note: i'm not sure how to reproduce or even test this. and i'm not even sure if this is the correct solution, but I saw some code that I thought could be buggy.

alternatively we could throw an error if `sliceSize < 0` or `offset > this._size`, because that could indicate a logic issue.

see discussion in https://community.transloadit.com/t/how-to-abort-hanging-companion-uploads/16488/10
