### PR TITLE
Fix HEAD not being retried for HTTP 500 category responses

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -615,6 +615,11 @@ class BaseUpload {
         if (status === 423) {
           this._emitHttpError(req, res, 'tus: upload is currently locked; retry later')
           return
+        } else if (inStatusCategory(status, 500)) {
+          // Run retry logic if the server has an error, e.g. 502 Bad Gateway when
+          // proxied server is temporarily down. See issue #579.
+          this._emitHttpError(req, res, 'tus: resuming upload resulted in HTTP 500 category error')
+          return
         }
 
         if (inStatusCategory(status, 400)) {


### PR DESCRIPTION
Tentative PR to help with #579.

This fixes the immediate issue of key HTTP 500 errors such as `502 Bad Gateway` not leading to retries.

But as described in https://github.com/tus/tus-js-client/issues/579#issuecomment-1508169053 I thikn that even more cases should lead to retry.