### PR TITLE
typescript: Fix DetailedError types missing possible nulls

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -126,6 +126,6 @@ export interface HttpResponse {
 
 export class DetailedError extends Error {
   originalRequest: HttpRequest
-  originalResponse: HttpResponse
-  causingError: Error
+  originalResponse: HttpResponse | null
+  causingError: Error | null
 }


### PR DESCRIPTION
Fixes #550.