### PR TITLE
Error out if source provides less data than expected

### DIFF
--- a/lib/browser/sources/FileSource.js
+++ b/lib/browser/sources/FileSource.js
@@ -17,7 +17,8 @@ export default class FileSource {
     }
 
     const value = this._file.slice(start, end)
-    return Promise.resolve({ value })
+    const done = end >= this.size
+    return Promise.resolve({ value, done })
   }
 
   close() {

--- a/lib/node/sources/BufferSource.js
+++ b/lib/node/sources/BufferSource.js
@@ -7,7 +7,8 @@ export default class BufferSource {
   slice(start, end) {
     const value = this._buffer.slice(start, end)
     value.size = value.length
-    return Promise.resolve({ value })
+    const done = end >= this.size
+    return Promise.resolve({ value, done })
   }
 
   close() {}

--- a/lib/node/sources/FileSource.js
+++ b/lib/node/sources/FileSource.js
@@ -46,8 +46,9 @@ class FileSource {
       end: offset + end - 1,
       autoClose: true,
     })
-    stream.size = end - start
-    return Promise.resolve({ value: stream })
+    stream.size = Math.min(end - start, this.size)
+    const done = stream.size >= this.size
+    return Promise.resolve({ value: stream, done })
   }
 
   close() {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -782,12 +782,28 @@ class BaseUpload {
     }
 
     return this._source.slice(start, end).then(({ value, done }) => {
+      const valueSize = value && value.size ? value.size : 0
+
       // If the upload length is deferred, the upload size was not specified during
       // upload creation. So, if the file reader is done reading, we know the total
       // upload size and can tell the tus server.
       if (this.options.uploadLengthDeferred && done) {
-        this._size = this._offset + (value && value.size ? value.size : 0)
+        this._size = this._offset + valueSize
         req.setHeader('Upload-Length', this._size)
+      }
+
+      // The specified uploadSize might not match the actual amount of data that a source
+      // provides. In these cases, we cannot successfully complete the upload, so we
+      // rather error out and let the user know. If not, tus-js-client will be stuck
+      // in a loop of repeating empty PATCH requests.
+      // See https://community.transloadit.com/t/how-to-abort-hanging-companion-uploads/16488/13
+      const newSize = this._offset + valueSize
+      if (!this.options.uploadLengthDeferred && done && newSize !== this._size) {
+        return Promise.reject(
+          new Error(
+            `upload was configured with a size of ${this._size} bytes, but the source is done after ${newSize} bytes`
+          )
+        )
       }
 
       if (value === null) {

--- a/test/spec/test-browser-specific.js
+++ b/test/spec/test-browser-specific.js
@@ -659,7 +659,7 @@ describe('tus', () => {
         await options.onSuccess.toBeCalled
       })
 
-      fit('should throw an error if the source provides less data than uploadSize', async () => {
+      it('should throw an error if the source provides less data than uploadSize', async () => {
         const reader = makeReader('hello world')
 
         const testStack = new TestHttpStack()

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -763,6 +763,42 @@ describe('tus', () => {
       )
     })
 
+    it('should throw an error if the source provides less data than uploadSize', async () => {
+      const testStack = new TestHttpStack()
+      const file = getBlob('hello world')
+      const options = {
+        httpStack: testStack,
+        uploadSize: 100,
+        endpoint: 'http://tus.io/uploads',
+        retryDelays: [],
+        onError: waitableFunction('onError'),
+      }
+
+      const upload = new tus.Upload(file, options)
+      upload.start()
+
+      const req = await testStack.nextRequest()
+      expect(req.url).toBe('http://tus.io/uploads')
+      expect(req.method).toBe('POST')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+
+      req.respondWith({
+        status: 204,
+        responseHeaders: {
+          Location: 'http://tus.io/uploads/foo',
+        },
+      })
+
+      console.log('1')
+
+      const err = await options.onError.toBeCalled
+      console.log('2')
+
+      expect(err.message).toBe(
+        'tus: failed to upload chunk at offset 0, caused by Error: upload was configured with a size of 100 bytes, but the source is done after 11 bytes, originated from request (method: PATCH, url: http://tus.io/uploads/foo, response code: n/a, response text: n/a, request id: n/a)'
+      )
+    })
+
     it('should throw if retryDelays is not an array', () => {
       const file = getBlob('hello world')
       const upload = new tus.Upload(file, {

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -789,11 +789,7 @@ describe('tus', () => {
         },
       })
 
-      console.log('1')
-
       const err = await options.onError.toBeCalled
-      console.log('2')
-
       expect(err.message).toBe(
         'tus: failed to upload chunk at offset 0, caused by Error: upload was configured with a size of 100 bytes, but the source is done after 11 bytes, originated from request (method: PATCH, url: http://tus.io/uploads/foo, response code: n/a, response text: n/a, request id: n/a)'
       )

--- a/test/spec/test-end-to-end.js
+++ b/test/spec/test-end-to-end.js
@@ -46,43 +46,6 @@ describe('tus', () => {
     )
 
     it(
-      'should upload to a real tus server even if the size is somehow wrong',
-      async () => {
-        return new Promise((resolve, reject) => {
-          const file = getBlob('hello world')
-          const options = {
-            endpoint: 'https://tusd.tusdemo.net/files/',
-            metadata: {
-              nonlatin: 'słońce',
-              number: 100,
-              filename: 'hello.txt',
-              filetype: 'text/plain',
-            },
-            onSuccess() {
-              expect(upload.url).toMatch(/^https:\/\/tusd\.tusdemo\.net\/files\//)
-              console.log('Upload URL:', upload.url) // eslint-disable-line no-console
-
-              resolve(upload)
-            },
-            onError(err) {
-              reject(err)
-            },
-          }
-
-          const upload = new tus.Upload(file, options)
-          upload.options.uploadSize = 10000;
-          upload.start()
-        })
-          .then(validateUploadContent)
-          .then((upload) => {
-            return upload.abort(true).then(() => upload)
-          })
-          .then(validateUploadDeletion)
-      },
-      END_TO_END_TIMEOUT
-    )
-
-    it(
       'should upload to a real tus server with creation-with-upload',
       async () => {
         return new Promise((resolve, reject) => {

--- a/test/spec/test-end-to-end.js
+++ b/test/spec/test-end-to-end.js
@@ -46,6 +46,43 @@ describe('tus', () => {
     )
 
     it(
+      'should upload to a real tus server even if the size is somehow wrong',
+      async () => {
+        return new Promise((resolve, reject) => {
+          const file = getBlob('hello world')
+          const options = {
+            endpoint: 'https://tusd.tusdemo.net/files/',
+            metadata: {
+              nonlatin: 'słońce',
+              number: 100,
+              filename: 'hello.txt',
+              filetype: 'text/plain',
+            },
+            onSuccess() {
+              expect(upload.url).toMatch(/^https:\/\/tusd\.tusdemo\.net\/files\//)
+              console.log('Upload URL:', upload.url) // eslint-disable-line no-console
+
+              resolve(upload)
+            },
+            onError(err) {
+              reject(err)
+            },
+          }
+
+          const upload = new tus.Upload(file, options)
+          upload.options.uploadSize = 10000;
+          upload.start()
+        })
+          .then(validateUploadContent)
+          .then((upload) => {
+            return upload.abort(true).then(() => upload)
+          })
+          .then(validateUploadDeletion)
+      },
+      END_TO_END_TIMEOUT
+    )
+
+    it(
       'should upload to a real tus server with creation-with-upload',
       async () => {
         return new Promise((resolve, reject) => {

--- a/test/spec/test-node-specific.js
+++ b/test/spec/test-node-specific.js
@@ -28,192 +28,268 @@ describe('tus', () => {
       await expectHelloWorldUpload(buffer, options)
     })
 
-    it('should reject streams without specifying the size', async () => {
-      const input = new stream.PassThrough()
-      const options = {
-        endpoint: '/uploads',
-        chunkSize: 100,
-        onError: waitableFunction('onError'),
-      }
+    describe('uploading from a stream', () => {
+      it('should reject streams without specifying the size', async () => {
+        const input = new stream.PassThrough()
+        const options = {
+          endpoint: '/uploads',
+          chunkSize: 100,
+          onError: waitableFunction('onError'),
+        }
 
-      const upload = new tus.Upload(input, options)
-      upload.start()
+        const upload = new tus.Upload(input, options)
+        upload.start()
 
-      const err = await options.onError.toBeCalled
-      expect(err.message).toBe(
-        "tus: cannot automatically derive upload's size from input. Specify it manually using the `uploadSize` option or use the `uploadLengthDeferred` option"
-      )
-    })
-
-    it('should reject streams without specifying the chunkSize', async () => {
-      const input = new stream.PassThrough()
-      const options = {
-        endpoint: '/uploads',
-        onError: waitableFunction('onError'),
-      }
-
-      const upload = new tus.Upload(input, options)
-      upload.start()
-
-      const err = await options.onError.toBeCalled
-      expect(err.message).toBe(
-        'cannot create source for stream without a finite value for the `chunkSize` option; specify a chunkSize to control the memory consumption'
-      )
-    })
-
-    it('should accept Readable streams', async () => {
-      const input = new stream.PassThrough()
-      const options = {
-        httpStack: new TestHttpStack(),
-        endpoint: '/uploads',
-        chunkSize: 7,
-        uploadSize: 11,
-      }
-
-      input.end('hello WORLD')
-      await expectHelloWorldUpload(input, options)
-    })
-
-    it('should accept stream-like objects', async () => {
-      // This function returns an object that works like a stream but does not inherit stream.Readable
-      const input = intoStream('hello WORLD')
-      const options = {
-        httpStack: new TestHttpStack(),
-        endpoint: '/uploads',
-        chunkSize: 7,
-        uploadSize: 11,
-      }
-
-      await expectHelloWorldUpload(input, options)
-    })
-
-    it('should accept Readable streams with deferred size', async () => {
-      const input = new stream.PassThrough()
-      const options = {
-        httpStack: new TestHttpStack(),
-        endpoint: '/uploads',
-        chunkSize: 7,
-        uploadLengthDeferred: true,
-      }
-
-      input.end('hello WORLD')
-      await expectHelloWorldUpload(input, options)
-    })
-
-    it('should accept fs.ReadStream', async () => {
-      // Create a temporary file
-      const path = temp.path()
-      fs.writeFileSync(path, 'hello world')
-      const file = fs.createReadStream(path)
-
-      const options = {
-        httpStack: new TestHttpStack(),
-        endpoint: '/uploads',
-        chunkSize: 7,
-      }
-
-      await expectHelloWorldUpload(file, options)
-    })
-
-    it('should support parallelUploads and fs.ReadStream', async () => {
-      // Create a temporary file
-      const path = temp.path()
-      fs.writeFileSync(path, 'hello world')
-      const file = fs.createReadStream(path)
-
-      const testStack = new TestHttpStack()
-
-      const options = {
-        httpStack: testStack,
-        parallelUploads: 2,
-        endpoint: 'https://tus.io/uploads',
-        onProgress() {},
-        onSuccess: waitableFunction(),
-      }
-      spyOn(options, 'onProgress')
-
-      const upload = new tus.Upload(file, options)
-      upload.start()
-
-      let req = await testStack.nextRequest()
-      expect(req.url).toBe('https://tus.io/uploads')
-      expect(req.method).toBe('POST')
-      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(5)
-      expect(req.requestHeaders['Upload-Concat']).toBe('partial')
-
-      req.respondWith({
-        status: 201,
-        responseHeaders: {
-          Location: 'https://tus.io/uploads/upload1',
-        },
+        const err = await options.onError.toBeCalled
+        expect(err.message).toBe(
+          "tus: cannot automatically derive upload's size from input. Specify it manually using the `uploadSize` option or use the `uploadLengthDeferred` option"
+        )
       })
 
-      req = await testStack.nextRequest()
-      expect(req.url).toBe('https://tus.io/uploads/upload1')
-      expect(req.method).toBe('PATCH')
-      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
-      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
-      expect(req.body.size).toBe(5)
+      it('should reject streams without specifying the chunkSize', async () => {
+        const input = new stream.PassThrough()
+        const options = {
+          endpoint: '/uploads',
+          onError: waitableFunction('onError'),
+        }
 
-      req.respondWith({
-        status: 204,
-        responseHeaders: {
-          'Upload-Offset': 5,
-        },
+        const upload = new tus.Upload(input, options)
+        upload.start()
+
+        const err = await options.onError.toBeCalled
+        expect(err.message).toBe(
+          'cannot create source for stream without a finite value for the `chunkSize` option; specify a chunkSize to control the memory consumption'
+        )
       })
 
-      req = await testStack.nextRequest()
-      expect(req.url).toBe('https://tus.io/uploads')
-      expect(req.method).toBe('POST')
-      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(6)
-      expect(req.requestHeaders['Upload-Concat']).toBe('partial')
+      it('should accept Readable streams', async () => {
+        const input = new stream.PassThrough()
+        const options = {
+          httpStack: new TestHttpStack(),
+          endpoint: '/uploads',
+          chunkSize: 7,
+          uploadSize: 11,
+        }
 
-      req.respondWith({
-        status: 201,
-        responseHeaders: {
-          Location: 'https://tus.io/uploads/upload2',
-        },
+        input.end('hello WORLD')
+        await expectHelloWorldUpload(input, options)
       })
 
-      req = await testStack.nextRequest()
-      expect(req.url).toBe('https://tus.io/uploads/upload2')
-      expect(req.method).toBe('PATCH')
-      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
-      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
-      expect(req.body.size).toBe(6)
+      it('should accept stream-like objects', async () => {
+        // This function returns an object that works like a stream but does not inherit stream.Readable
+        const input = intoStream('hello WORLD')
+        const options = {
+          httpStack: new TestHttpStack(),
+          endpoint: '/uploads',
+          chunkSize: 7,
+          uploadSize: 11,
+        }
 
-      req.respondWith({
-        status: 204,
-        responseHeaders: {
-          'Upload-Offset': 6,
-        },
+        await expectHelloWorldUpload(input, options)
       })
 
-      req = await testStack.nextRequest()
-      expect(req.url).toBe('https://tus.io/uploads')
-      expect(req.method).toBe('POST')
-      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBeUndefined()
-      expect(req.requestHeaders['Upload-Concat']).toBe(
-        'final;https://tus.io/uploads/upload1 https://tus.io/uploads/upload2'
-      )
+      it('should accept Readable streams with deferred size', async () => {
+        const input = new stream.PassThrough()
+        const options = {
+          httpStack: new TestHttpStack(),
+          endpoint: '/uploads',
+          chunkSize: 7,
+          uploadLengthDeferred: true,
+        }
 
-      req.respondWith({
-        status: 201,
-        responseHeaders: {
-          Location: 'https://tus.io/uploads/upload3',
-        },
+        input.end('hello WORLD')
+        await expectHelloWorldUpload(input, options)
       })
 
-      await options.onSuccess.toBeCalled
+      it('should throw an error if the source provides less data than uploadSize', async () => {
+        const input = new stream.PassThrough()
+        input.end('hello world')
 
-      expect(upload.url).toBe('https://tus.io/uploads/upload3')
-      expect(options.onProgress).toHaveBeenCalledWith(5, 11)
-      expect(options.onProgress).toHaveBeenCalledWith(11, 11)
+        const testStack = new TestHttpStack()
+        const options = {
+          httpStack: testStack,
+          uploadSize: 100,
+          chunkSize: 100,
+          endpoint: 'http://tus.io/uploads',
+          retryDelays: [],
+          onError: waitableFunction('onError'),
+        }
+
+        const upload = new tus.Upload(input, options)
+        upload.start()
+
+        const req = await testStack.nextRequest()
+        expect(req.url).toBe('http://tus.io/uploads')
+        expect(req.method).toBe('POST')
+        expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+
+        req.respondWith({
+          status: 204,
+          responseHeaders: {
+            Location: 'http://tus.io/uploads/foo',
+          },
+        })
+
+        const err = await options.onError.toBeCalled
+        expect(err.message).toBe(
+          'tus: failed to upload chunk at offset 0, caused by Error: upload was configured with a size of 100 bytes, but the source is done after 11 bytes, originated from request (method: PATCH, url: http://tus.io/uploads/foo, response code: n/a, response text: n/a, request id: n/a)'
+        )
+      })
+    })
+
+    describe('uploading from a fs.ReadStream', () => {
+      it('should accept fs.ReadStream', async () => {
+        // Create a temporary file
+        const path = temp.path()
+        fs.writeFileSync(path, 'hello world')
+        const file = fs.createReadStream(path)
+
+        const options = {
+          httpStack: new TestHttpStack(),
+          endpoint: '/uploads',
+          chunkSize: 7,
+        }
+
+        await expectHelloWorldUpload(file, options)
+      })
+
+      it('should support parallelUploads and fs.ReadStream', async () => {
+        // Create a temporary file
+        const path = temp.path()
+        fs.writeFileSync(path, 'hello world')
+        const file = fs.createReadStream(path)
+
+        const testStack = new TestHttpStack()
+
+        const options = {
+          httpStack: testStack,
+          parallelUploads: 2,
+          endpoint: 'https://tus.io/uploads',
+          onProgress() {},
+          onSuccess: waitableFunction(),
+        }
+        spyOn(options, 'onProgress')
+
+        const upload = new tus.Upload(file, options)
+        upload.start()
+
+        let req = await testStack.nextRequest()
+        expect(req.url).toBe('https://tus.io/uploads')
+        expect(req.method).toBe('POST')
+        expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+        expect(req.requestHeaders['Upload-Length']).toBe(5)
+        expect(req.requestHeaders['Upload-Concat']).toBe('partial')
+
+        req.respondWith({
+          status: 201,
+          responseHeaders: {
+            Location: 'https://tus.io/uploads/upload1',
+          },
+        })
+
+        req = await testStack.nextRequest()
+        expect(req.url).toBe('https://tus.io/uploads/upload1')
+        expect(req.method).toBe('PATCH')
+        expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+        expect(req.requestHeaders['Upload-Offset']).toBe(0)
+        expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+        expect(req.body.size).toBe(5)
+
+        req.respondWith({
+          status: 204,
+          responseHeaders: {
+            'Upload-Offset': 5,
+          },
+        })
+
+        req = await testStack.nextRequest()
+        expect(req.url).toBe('https://tus.io/uploads')
+        expect(req.method).toBe('POST')
+        expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+        expect(req.requestHeaders['Upload-Length']).toBe(6)
+        expect(req.requestHeaders['Upload-Concat']).toBe('partial')
+
+        req.respondWith({
+          status: 201,
+          responseHeaders: {
+            Location: 'https://tus.io/uploads/upload2',
+          },
+        })
+
+        req = await testStack.nextRequest()
+        expect(req.url).toBe('https://tus.io/uploads/upload2')
+        expect(req.method).toBe('PATCH')
+        expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+        expect(req.requestHeaders['Upload-Offset']).toBe(0)
+        expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+        expect(req.body.size).toBe(6)
+
+        req.respondWith({
+          status: 204,
+          responseHeaders: {
+            'Upload-Offset': 6,
+          },
+        })
+
+        req = await testStack.nextRequest()
+        expect(req.url).toBe('https://tus.io/uploads')
+        expect(req.method).toBe('POST')
+        expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+        expect(req.requestHeaders['Upload-Length']).toBeUndefined()
+        expect(req.requestHeaders['Upload-Concat']).toBe(
+          'final;https://tus.io/uploads/upload1 https://tus.io/uploads/upload2'
+        )
+
+        req.respondWith({
+          status: 201,
+          responseHeaders: {
+            Location: 'https://tus.io/uploads/upload3',
+          },
+        })
+
+        await options.onSuccess.toBeCalled
+
+        expect(upload.url).toBe('https://tus.io/uploads/upload3')
+        expect(options.onProgress).toHaveBeenCalledWith(5, 11)
+        expect(options.onProgress).toHaveBeenCalledWith(11, 11)
+      })
+
+      it('should throw an error if the source provides less data than uploadSize', async () => {
+        // Create a temporary file
+        const path = temp.path()
+        fs.writeFileSync(path, 'hello world')
+        const file = fs.createReadStream(path)
+
+        const testStack = new TestHttpStack()
+        const options = {
+          httpStack: testStack,
+          uploadSize: 100,
+          chunkSize: 100,
+          endpoint: 'http://tus.io/uploads',
+          retryDelays: [],
+          onError: waitableFunction('onError'),
+        }
+
+        const upload = new tus.Upload(file, options)
+        upload.start()
+
+        const req = await testStack.nextRequest()
+        expect(req.url).toBe('http://tus.io/uploads')
+        expect(req.method).toBe('POST')
+        expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+
+        req.respondWith({
+          status: 204,
+          responseHeaders: {
+            Location: 'http://tus.io/uploads/foo',
+          },
+        })
+
+        const err = await options.onError.toBeCalled
+        expect(err.message).toBe(
+          'tus: failed to upload chunk at offset 0, caused by Error: upload was configured with a size of 100 bytes, but the source is done after 11 bytes, originated from request (method: PATCH, url: http://tus.io/uploads/foo, response code: n/a, response text: n/a, request id: n/a)'
+        )
+      })
     })
 
     it('should pass through errors from the request', async () => {


### PR DESCRIPTION
Hopefully I can get some help with this one. We're experiencing Companion sending insane amounts of zero-byte patch requests.

We _are guessing_ that this is due to some files `Content-Length` being over-reported when doing `HEAD` request in Companion to get the file size, essentially doing what this test does (setting the `options.uploadSize` too large).

I tried applying the diff from #556 but that does not appear to fix the issue. Would appreciate any help or ideas here. It _feels_ like it should not be "too hard" to simply fail an upload where the next patch would be length=0 but maybe I'm missing something here.
