### PR TITLE
Add support for IETF resumable upload draft

### DIFF
--- a/demos/browser/demo.js
+++ b/demos/browser/demo.js
@@ -71,6 +71,7 @@ function startUpload() {
       filename: file.name,
       filetype: file.type,
     },
+    protocol: 'ietf-draft-01',
     onError(error) {
       if (error.originalRequest) {
         if (window.confirm(`Failed because: ${error}\nDo you want to retry?`)) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -399,6 +399,12 @@ interface SliceResult {
 }
 ```
 
+#### protocol
+
+_Default value:_ `'tus-v1'`
+
+tus-js-client uses the [tus v1.0.0 upload protocol](https://tus.io/protocols/resumable-upload) by default. It also includes experimental support for [the draft of Resumable Uploads For HTTP](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/) developed in the HTTP working group of the IETF. By setting the `protocol` option to `'ietf-draft-03'`, tus-js-client will use the protocol as defined in the draft version 03. Please be aware that this feature is experimental and that this option might change in breaking ways in non-major releases.
+
 ## tus.Upload(file, options)
 
 The constructor for the `tus.Upload` class. The upload will not be started automatically, use `start` to do so.

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -5,7 +5,7 @@ import { log } from './logger.js'
 import uuid from './uuid.js'
 
 const PROTOCOL_TUS_V1 = 'tus-v1'
-const PROTOCOL_IETF_DRAFT_01 = 'ietf-draft-01'
+const PROTOCOL_IETF_DRAFT_03 = 'ietf-draft-03'
 
 const defaultOptions = {
   endpoint: null,
@@ -176,7 +176,7 @@ class BaseUpload {
       return
     }
 
-    if (![PROTOCOL_TUS_V1, PROTOCOL_IETF_DRAFT_01].includes(this.options.protocol)) {
+    if (![PROTOCOL_TUS_V1, PROTOCOL_IETF_DRAFT_03].includes(this.options.protocol)) {
       this._emitError(new Error(`tus: unsupported protocol ${this.options.protocol}`))
       return
     }
@@ -595,8 +595,8 @@ class BaseUpload {
       this._offset = 0
       promise = this._addChunkToRequest(req)
     } else {
-      if (this.options.protocol === PROTOCOL_IETF_DRAFT_01) {
-        req.setHeader('Upload-Incomplete', '?1')
+      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03) {
+        req.setHeader('Upload-Complete', '?0')
       }
       promise = this._sendRequest(req, null)
     }
@@ -828,8 +828,8 @@ class BaseUpload {
         return this._sendRequest(req)
       }
 
-      if (this.options.protocol === PROTOCOL_IETF_DRAFT_01) {
-        req.setHeader('Upload-Incomplete', done ? '?0' : '?1')
+      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03) {
+        req.setHeader('Upload-Complete', done ? '?1' : '?0')
       }
       this._emitProgress(this._offset, this._size)
       return this._sendRequest(req, value)
@@ -962,8 +962,8 @@ function inStatusCategory(status, category) {
 function openRequest(method, url, options) {
   const req = options.httpStack.createRequest(method, url)
 
-  if (options.protocol === PROTOCOL_IETF_DRAFT_01) {
-    req.setHeader('Upload-Draft-Interop-Version', '3')
+  if (options.protocol === PROTOCOL_IETF_DRAFT_03) {
+    req.setHeader('Upload-Draft-Interop-Version', '5')
   } else {
     req.setHeader('Tus-Resumable', '1.0.0')
   }

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -4,8 +4,8 @@ import DetailedError from './error.js'
 import { log } from './logger.js'
 import uuid from './uuid.js'
 
-const PROTOCOL_TUS_V1 = "tus-v1"
-const PROTOCOL_IETF_DRAFT_01 = "ietf-draft-01"
+const PROTOCOL_TUS_V1 = 'tus-v1'
+const PROTOCOL_IETF_DRAFT_01 = 'ietf-draft-01'
 
 const defaultOptions = {
   endpoint: null,
@@ -695,7 +695,11 @@ class BaseUpload {
         }
 
         const length = parseInt(res.getHeader('Upload-Length'), 10)
-        if (Number.isNaN(length) && !this.options.uploadLengthDeferred && this.options.protocol === PROTOCOL_TUS_V1) {
+        if (
+          Number.isNaN(length) &&
+          !this.options.uploadLengthDeferred &&
+          this.options.protocol === PROTOCOL_TUS_V1
+        ) {
           this._emitHttpError(req, res, 'tus: invalid or missing length value')
           return
         }

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -4,6 +4,9 @@ import DetailedError from './error.js'
 import { log } from './logger.js'
 import uuid from './uuid.js'
 
+const PROTOCOL_TUS_V1 = "tus-v1"
+const PROTOCOL_IETF_DRAFT_01 = "ietf-draft-01"
+
 const defaultOptions = {
   endpoint: null,
 
@@ -37,6 +40,8 @@ const defaultOptions = {
   urlStorage: null,
   fileReader: null,
   httpStack: null,
+
+  protocol: PROTOCOL_TUS_V1,
 }
 
 class BaseUpload {
@@ -167,6 +172,11 @@ class BaseUpload {
 
     if (!file) {
       this._emitError(new Error('tus: no file or stream to upload provided'))
+      return
+    }
+
+    if (![PROTOCOL_TUS_V1, PROTOCOL_IETF_DRAFT_01].includes(this.options.protocol)) {
+      this._emitError(new Error(`tus: unsupported protocol ${this.options.protocol}`))
       return
     }
 
@@ -584,6 +594,9 @@ class BaseUpload {
       this._offset = 0
       promise = this._addChunkToRequest(req)
     } else {
+      if (this.options.protocol === PROTOCOL_IETF_DRAFT_01) {
+        req.setHeader('Upload-Incomplete', '?1')
+      }
       promise = this._sendRequest(req, null)
     }
 
@@ -682,7 +695,7 @@ class BaseUpload {
         }
 
         const length = parseInt(res.getHeader('Upload-Length'), 10)
-        if (Number.isNaN(length) && !this.options.uploadLengthDeferred) {
+        if (Number.isNaN(length) && !this.options.uploadLengthDeferred && this.options.protocol === PROTOCOL_TUS_V1) {
           this._emitHttpError(req, res, 'tus: invalid or missing length value')
           return
         }
@@ -792,6 +805,10 @@ class BaseUpload {
 
       if (value === null) {
         return this._sendRequest(req)
+      }
+
+      if (this.options.protocol === PROTOCOL_IETF_DRAFT_01) {
+        req.setHeader('Upload-Incomplete', done ? '?0' : '?1')
       }
       this._emitProgress(this._offset, this._size)
       return this._sendRequest(req, value)
@@ -924,7 +941,11 @@ function inStatusCategory(status, category) {
 function openRequest(method, url, options) {
   const req = options.httpStack.createRequest(method, url)
 
-  req.setHeader('Tus-Resumable', '1.0.0')
+  if (options.protocol === PROTOCOL_IETF_DRAFT_01) {
+    req.setHeader('Upload-Draft-Interop-Version', '3')
+  } else {
+    req.setHeader('Tus-Resumable', '1.0.0')
+  }
   const headers = options.headers || {}
 
   Object.entries(headers).forEach(([name, value]) => {


### PR DESCRIPTION
This patch provides a first, rough support for the new, upcoming resumable uploads draft. Details of its specification are currently available at https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/03/. With this PR we can gain first experience about the aspects and issues with implementing the draft.

This work is not yet ready for production. As details of the specification change, this PR will change as well.