### PR TITLE
Drop support for Node 14 and 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,12 @@ jobs:
             suite: 'puppeteer'
           - desc: 'Types'
             suite: 'types'
-          - desc: 'Node.js 14'
-            suite: 'node'
-            node: 14
-          - desc: 'Node.js 16'
-            suite: 'node'
-            node: 16
           - desc: 'Node.js 18'
             suite: 'node'
             node: 18
+          - desc: 'Node.js 20'
+            suite: 'node'
+            node: 20
     name: ${{ matrix.desc }}
     steps:
       - name: Check out sources
@@ -39,7 +36,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node || 16 }}
+          node-version: ${{ matrix.node || 20 }}
       - name: Install dependencies
         uses: sergioramos/yarn-actions/install@v6
         with:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,7 @@ who provide their great service glady for Open Source project for free.
 
 ## Node.js support
 
-tus-js-client is tested and known to work in Node.js v14 or newer.
+tus-js-client is tested and known to work in Node.js v18 or newer.
 
 Since Node's environment is quite different than a browser's runtime and
 provides other capabilities but also restrictions, tus-js-client will have a

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "./lib/node/index.js": "./lib/browser/index.js"
   },
   "types": "./lib/index.d.ts",
+  "engines": {
+    "node": ">=18"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/tus/tus-js-client.git"


### PR DESCRIPTION
Closes https://github.com/tus/tus-js-client/issues/615.

Node 14 is already unsupported for a long time and Node 16 will be EOL'ed in one week. See https://nodejs.dev/en/about/releases/. tus-js-client does not have a direct problem with those versions, but its dependencies are not compatible.