### PR TITLE
move default retry logic on to defaultOptions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -33,7 +33,7 @@ interface UploadOptions {
   onSuccess?: (() => void) | null
   onError?: ((error: Error | DetailedError) => void) | null
   onShouldRetry?:
-    | ((error: Error | DetailedError, retryAttempt: number, options: UploadOptions) => boolean)
+    | ((error: DetailedError, retryAttempt: number, options: UploadOptions) => boolean)
     | null
   onUploadUrlAvailable?: (() => void) | null
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -23,7 +23,10 @@ const defaultOptions = {
   addRequestId: false,
   onBeforeRequest: null,
   onAfterResponse: null,
-  onShouldRetry: null,
+  onShouldRetry: (err, retryAttempt, options) => {
+    const status = err.originalResponse ? err.originalResponse.getStatus() : 0
+    return (!inStatusCategory(status, 400) || status === 409 || status === 423) && isOnline()
+  },
 
   chunkSize: Infinity,
   retryDelays: [0, 1000, 3000, 5000],
@@ -1026,8 +1029,7 @@ function shouldRetry(err, retryAttempt, options) {
     return options.onShouldRetry(err, retryAttempt, options)
   }
 
-  const status = err.originalResponse ? err.originalResponse.getStatus() : 0
-  return (!inStatusCategory(status, 400) || status === 409 || status === 423) && isOnline()
+  return defaultOptions.onShouldRetry(err, retryAttempt, options);
 }
 
 /**


### PR DESCRIPTION
closes #636 

it was suggested that the default value of `onShouldRetry` should be set to `shouldRetry` but that won't work because `shouldRetry` calls `onShouldRetry`, so I opted to move the code at the bottom of `shouldRetry` into a function declared on `defaultOptions`. I wasn't quite sure what we wanted to do if a user explicitly set `onShouldRetry` to null. Currently the default logic would still be used, so that's what I preserved here, though it does look a bit awkward.

I wasn't able to run tests or execute a build locally. I kept getting a build error about a subdirectory or file already existing.