### PR TITLE
Fix for issue #652: retryDelays type missing null

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -44,7 +44,7 @@ interface UploadOptions {
   onAfterResponse?: (req: HttpRequest, res: HttpResponse) => void | Promise<void>
 
   chunkSize?: number
-  retryDelays?: number[]
+  retryDelays?: number[] | null
   parallelUploads?: number
   parallelUploadBoundaries?: { start: number; end: number }[] | null
   storeFingerprintForResuming?: boolean


### PR DESCRIPTION
Issue: https://github.com/tus/tus-js-client/issues/652