### PR TITLE
Remove dependency on `window` to work in Web Workers

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -28,9 +28,12 @@ class Upload extends BaseUpload {
   }
 }
 
-const { XMLHttpRequest, Blob } = window
-
-const isSupported = XMLHttpRequest && Blob && typeof Blob.prototype.slice === 'function'
+/* eslint-disable no-restricted-globals, valid-typeof */
+const isSupported =
+  typeof self !== undefined &&
+  'XMLHttpRequest' in self &&
+  'Blob' in self &&
+  typeof Blob.prototype.slice === 'function'
 
 export {
   Upload,

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -28,11 +28,10 @@ class Upload extends BaseUpload {
   }
 }
 
-/* eslint-disable no-restricted-globals, valid-typeof */
+// Note: We don't reference `window` here because these classes also exist in a Web Worker's context.
 const isSupported =
-  typeof self !== undefined &&
-  'XMLHttpRequest' in self &&
-  'Blob' in self &&
+  typeof XMLHttpRequest === 'function' &&
+  typeof Blob === 'function' &&
   typeof Blob.prototype.slice === 'function'
 
 export {

--- a/lib/browser/urlStorage.js
+++ b/lib/browser/urlStorage.js
@@ -1,5 +1,6 @@
 let hasStorage = false
 try {
+  // Note: localStorage does not exist in the Web Worker's context, so we must use window here.
   hasStorage = 'localStorage' in window
 
   // Attempt to store and read entries from the local storage to detect Private

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -984,14 +984,10 @@ async function sendRequest(req, body, options) {
  */
 function isOnline() {
   let online = true
-  if (
-    typeof window !== 'undefined' &&
-    // eslint-disable-next-line no-undef
-    'navigator' in window &&
-    // eslint-disable-next-line no-undef
-    window.navigator.onLine === false
-  ) {
-    // eslint-disable-line no-undef
+  // Note: We don't reference `window` here because the navigator object also exists
+  // in a Web Worker's context.
+  // eslint-disable-next-line no-undef
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     online = false
   }
 


### PR DESCRIPTION
Replace `window` in `/lib/browser/index.js` with `self` .

Fixes #658.