### PR TITLE
Add metadata into parallel uploads.

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -331,7 +331,8 @@ class BaseUpload {
               parallelUploads: 1,
               // Reset this option as we are not doing a parallel upload.
               parallelUploadBoundaries: null,
-              metadata: {},
+              metadata: { ...this.options.metadata
+              },
               // Add the header to indicate the this is a partial upload.
               headers: {
                 ...this.options.headers,

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -311,9 +311,9 @@ class BaseUpload {
     // Create an empty list for storing the upload URLs
     this._parallelUploadUrls = new Array(parts.length)
 
-    const metadata = {};
+    let partialMetadata = {};
     if (this.options.retainMetadataForParallelUploads) {
-      metadata = { ...this.options.metadata };
+      partialMetadata = { ...this.options.metadata };
     }
 
     // Generate a promise for each slice that will be resolve if the respective
@@ -337,7 +337,7 @@ class BaseUpload {
               parallelUploads: 1,
               // Reset this option as we are not doing a parallel upload.
               parallelUploadBoundaries: null,
-              metadata: metadata,
+              metadata: partialMetadata,
               // Add the header to indicate the this is a partial upload.
               headers: {
                 ...this.options.headers,

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -32,6 +32,7 @@ const defaultOptions = {
   retryDelays: [0, 1000, 3000, 5000],
   parallelUploads: 1,
   parallelUploadBoundaries: null,
+  retainMetadataForParallelUploads: false,
   storeFingerprintForResuming: true,
   removeFingerprintOnSuccess: false,
   uploadLengthDeferred: false,
@@ -310,6 +311,11 @@ class BaseUpload {
     // Create an empty list for storing the upload URLs
     this._parallelUploadUrls = new Array(parts.length)
 
+    const metadata = {};
+    if (this.options.retainMetadataForParallelUploads) {
+      metadata = { ...this.options.metadata };
+    }
+
     // Generate a promise for each slice that will be resolve if the respective
     // upload is completed.
     const uploads = parts.map((part, index) => {
@@ -331,8 +337,7 @@ class BaseUpload {
               parallelUploads: 1,
               // Reset this option as we are not doing a parallel upload.
               parallelUploadBoundaries: null,
-              metadata: { ...this.options.metadata
-              },
+              metadata: metadata,
               // Add the header to indicate the this is a partial upload.
               headers: {
                 ...this.options.headers,

--- a/test/spec/test-parallel-uploads.js
+++ b/test/spec/test-parallel-uploads.js
@@ -38,6 +38,173 @@ describe('tus', () => {
       )
     })
 
+    it('should maintain metadata when retainMetadataForParallelUploads option is set to true', async () => {
+      const testStack = new TestHttpStack()
+
+      const testUrlStorage = {
+        addUpload: (fingerprint, upload) => {
+          expect(fingerprint).toBe('fingerprinted')
+          expect(upload.uploadUrl).toBeUndefined()
+          expect(upload.size).toBe(11)
+          expect(upload.parallelUploadUrls).toEqual([
+            'https://tus.io/uploads/upload1',
+            'https://tus.io/uploads/upload2',
+          ])
+
+          return Promise.resolve('tus::fingerprinted::1337')
+        },
+        removeUpload: (urlStorageKey) => {
+          expect(urlStorageKey).toBe('tus::fingerprinted::1337')
+          return Promise.resolve()
+        },
+      }
+      spyOn(testUrlStorage, 'removeUpload').and.callThrough()
+      spyOn(testUrlStorage, 'addUpload').and.callThrough()
+
+      const file = getBlob('hello world')
+      const options = {
+        httpStack: testStack,
+        urlStorage: testUrlStorage,
+        storeFingerprintForResuming: true,
+        removeFingerprintOnSuccess: true,
+        retainMetadataForParallelUploads: true,
+        parallelUploads: 2,
+        retryDelays: [10],
+        endpoint: 'https://tus.io/uploads',
+        headers: {
+          Custom: 'blargh',
+        },
+        metadata: {
+          foo: 'hello',
+        },
+        onProgress() {},
+        onSuccess: waitableFunction(),
+        fingerprint: () => Promise.resolve('fingerprinted'),
+      }
+      spyOn(options, 'onProgress')
+
+      const upload = new tus.Upload(file, options)
+      upload.start()
+
+      let req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads')
+      expect(req.method).toBe('POST')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Length']).toBe(5)
+      expect(req.requestHeaders['Upload-Concat']).toBe('partial')
+      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
+
+      req.respondWith({
+        status: 201,
+        responseHeaders: {
+          Location: 'https://tus.io/uploads/upload1',
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads')
+      expect(req.method).toBe('POST')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Length']).toBe(6)
+      expect(req.requestHeaders['Upload-Concat']).toBe('partial')
+      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
+
+      req.respondWith({
+        status: 201,
+        responseHeaders: {
+          Location: 'https://tus.io/uploads/upload2',
+        },
+      })
+
+      req = await testStack.nextRequest()
+
+      // Assert that the URLs have been stored.
+      expect(testUrlStorage.addUpload).toHaveBeenCalled()
+
+      expect(req.url).toBe('https://tus.io/uploads/upload1')
+      expect(req.method).toBe('PATCH')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+      expect(req.body.size).toBe(5)
+
+      req.respondWith({
+        status: 204,
+        responseHeaders: {
+          'Upload-Offset': 5,
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads/upload2')
+      expect(req.method).toBe('PATCH')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+      expect(req.body.size).toBe(6)
+
+      // Return an error to ensure that the individual partial upload is properly retried.
+      req.respondWith({
+        status: 500,
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads/upload2')
+      expect(req.method).toBe('HEAD')
+
+      req.respondWith({
+        status: 204,
+        responseHeaders: {
+          'Upload-Length': 11,
+          'Upload-Offset': 0,
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads/upload2')
+      expect(req.method).toBe('PATCH')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
+      expect(req.body.size).toBe(6)
+
+      req.respondWith({
+        status: 204,
+        responseHeaders: {
+          'Upload-Offset': 6,
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.url).toBe('https://tus.io/uploads')
+      expect(req.method).toBe('POST')
+      expect(req.requestHeaders.Custom).toBe('blargh')
+      expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
+      expect(req.requestHeaders['Upload-Length']).toBeUndefined()
+      expect(req.requestHeaders['Upload-Concat']).toBe(
+        'final;https://tus.io/uploads/upload1 https://tus.io/uploads/upload2',
+      )
+      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
+
+      req.respondWith({
+        status: 201,
+        responseHeaders: {
+          Location: 'https://tus.io/uploads/upload3',
+        },
+      })
+
+      await options.onSuccess.toBeCalled
+
+      expect(upload.url).toBe('https://tus.io/uploads/upload3')
+      expect(options.onProgress).toHaveBeenCalledWith(5, 11)
+      expect(options.onProgress).toHaveBeenCalledWith(11, 11)
+      expect(testUrlStorage.removeUpload).toHaveBeenCalled()
+    })
     it('should split a file into multiple parts and create an upload for each', async () => {
       const testStack = new TestHttpStack()
 
@@ -92,7 +259,7 @@ describe('tus', () => {
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
       expect(req.requestHeaders['Upload-Length']).toBe(5)
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
-      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
+      expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
 
       req.respondWith({
         status: 201,
@@ -108,7 +275,7 @@ describe('tus', () => {
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
       expect(req.requestHeaders['Upload-Length']).toBe(6)
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
-      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
+      expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
 
       req.respondWith({
         status: 201,

--- a/test/spec/test-parallel-uploads.js
+++ b/test/spec/test-parallel-uploads.js
@@ -92,7 +92,7 @@ describe('tus', () => {
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
       expect(req.requestHeaders['Upload-Length']).toBe(5)
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
-      expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
+      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
 
       req.respondWith({
         status: 201,
@@ -108,7 +108,7 @@ describe('tus', () => {
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
       expect(req.requestHeaders['Upload-Length']).toBe(6)
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
-      expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
+      expect(req.requestHeaders['Upload-Metadata']).toBe('foo aGVsbG8=')
 
       req.respondWith({
         status: 201,


### PR DESCRIPTION
👋  This PR is more of a proposal to allow for parallel uploads to keep the metadata from the original request. My team has found that maintaining metadata in the parallel upload requests would benefit our use case.

The PR does two main things:
1.  Adds an option `retainMetadataForParallelUploads` that is defaulted to false. This option would be for our use case (or anyone else's) that would allow the retention of metadata in partial uploads, too.
2. Checks the `retainMetadataForParallelUploads` option during the parallel upload logic. If it's set to true, then we ensure the metadata is maintained, if it is false (default behavior), we remove it.