### PR TITLE
Only pass strings to `HttpRequest#setHeader`

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -581,7 +581,7 @@ class BaseUpload {
     if (this.options.uploadLengthDeferred) {
       req.setHeader('Upload-Defer-Length', '1')
     } else {
-      req.setHeader('Upload-Length',`${this._size}`))
+      req.setHeader('Upload-Length', `${this._size}`)
     }
 
     // Add metadata if values have been added

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -155,23 +155,6 @@ class BaseUpload {
       })
   }
 
-  static convertToStringHeaderValue(val) {
-    if (val === null || val === undefined) {
-      return ''
-    } else if (Array.isArray(val)) {
-      return val.join(',')
-    } else if (
-      typeof val === 'string' ||
-      typeof val === 'number' ||
-      typeof val === 'boolean' ||
-      typeof val === 'symbol'
-    ) {
-      return val.toString()
-    } else if (typeof val === 'object') {
-      return Object.values(val).join(',')
-    }
-  }
-
   findPreviousUploads() {
     return this.options
       .fingerprint(this.file, this.options)
@@ -395,7 +378,7 @@ class BaseUpload {
         // Add metadata if values have been added
         const metadata = encodeMetadata(this.options.metadata)
         if (metadata !== '') {
-          req.setHeader('Upload-Metadata', BaseUpload.convertToStringHeaderValue(metadata))
+          req.setHeader('Upload-Metadata', metadata)
         }
 
         return this._sendRequest(req, null)
@@ -598,13 +581,13 @@ class BaseUpload {
     if (this.options.uploadLengthDeferred) {
       req.setHeader('Upload-Defer-Length', '1')
     } else {
-      req.setHeader('Upload-Length', BaseUpload.convertToStringHeaderValue(this._size))
+      req.setHeader('Upload-Length',`${this._size}`))
     }
 
     // Add metadata if values have been added
     const metadata = encodeMetadata(this.options.metadata)
     if (metadata !== '') {
-      req.setHeader('Upload-Metadata', BaseUpload.convertToStringHeaderValue(metadata))
+      req.setHeader('Upload-Metadata', metadata)
     }
 
     let promise
@@ -771,7 +754,7 @@ class BaseUpload {
       req = this._openRequest('PATCH', this.url)
     }
 
-    req.setHeader('Upload-Offset', BaseUpload.convertToStringHeaderValue(this._offset))
+    req.setHeader('Upload-Offset', `${this._offset}`)
     const promise = this._addChunkToRequest(req)
 
     promise
@@ -827,7 +810,7 @@ class BaseUpload {
       // upload size and can tell the tus server.
       if (this.options.uploadLengthDeferred && done) {
         this._size = this._offset + valueSize
-        req.setHeader('Upload-Length', BaseUpload.convertToStringHeaderValue(this._size))
+        req.setHeader('Upload-Length', `${this._size}`)
       }
 
       // The specified uploadSize might not match the actual amount of data that a source
@@ -990,7 +973,7 @@ function openRequest(method, url, options) {
   const headers = options.headers || {}
 
   for (const [name, value] of Object.entries(headers)) {
-    req.setHeader(name, BaseUpload.convertToStringHeaderValue(value))
+    req.setHeader(name, value)
   }
 
   if (options.addRequestId) {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -155,6 +155,23 @@ class BaseUpload {
       })
   }
 
+  static convertToStringHeaderValue(val) {
+    if (val === null || val === undefined) {
+      return ''
+    } else if (Array.isArray(val)) {
+      return val.join(',')
+    } else if (
+      typeof val === 'string' ||
+      typeof val === 'number' ||
+      typeof val === 'boolean' ||
+      typeof val === 'symbol'
+    ) {
+      return val.toString()
+    } else if (typeof val === 'object') {
+      return Object.values(val).join(',')
+    }
+  }
+
   findPreviousUploads() {
     return this.options
       .fingerprint(this.file, this.options)
@@ -378,7 +395,7 @@ class BaseUpload {
         // Add metadata if values have been added
         const metadata = encodeMetadata(this.options.metadata)
         if (metadata !== '') {
-          req.setHeader('Upload-Metadata', metadata)
+          req.setHeader('Upload-Metadata', BaseUpload.convertToStringHeaderValue(metadata))
         }
 
         return this._sendRequest(req, null)
@@ -579,15 +596,15 @@ class BaseUpload {
     const req = this._openRequest('POST', this.options.endpoint)
 
     if (this.options.uploadLengthDeferred) {
-      req.setHeader('Upload-Defer-Length', 1)
+      req.setHeader('Upload-Defer-Length', '1')
     } else {
-      req.setHeader('Upload-Length', this._size)
+      req.setHeader('Upload-Length', BaseUpload.convertToStringHeaderValue(this._size))
     }
 
     // Add metadata if values have been added
     const metadata = encodeMetadata(this.options.metadata)
     if (metadata !== '') {
-      req.setHeader('Upload-Metadata', metadata)
+      req.setHeader('Upload-Metadata', BaseUpload.convertToStringHeaderValue(metadata))
     }
 
     let promise
@@ -754,7 +771,7 @@ class BaseUpload {
       req = this._openRequest('PATCH', this.url)
     }
 
-    req.setHeader('Upload-Offset', this._offset)
+    req.setHeader('Upload-Offset', BaseUpload.convertToStringHeaderValue(this._offset))
     const promise = this._addChunkToRequest(req)
 
     promise
@@ -810,7 +827,7 @@ class BaseUpload {
       // upload size and can tell the tus server.
       if (this.options.uploadLengthDeferred && done) {
         this._size = this._offset + valueSize
-        req.setHeader('Upload-Length', this._size)
+        req.setHeader('Upload-Length', BaseUpload.convertToStringHeaderValue(this._size))
       }
 
       // The specified uploadSize might not match the actual amount of data that a source
@@ -973,7 +990,7 @@ function openRequest(method, url, options) {
   const headers = options.headers || {}
 
   for (const [name, value] of Object.entries(headers)) {
-    req.setHeader(name, value)
+    req.setHeader(name, BaseUpload.convertToStringHeaderValue(value))
   }
 
   if (options.addRequestId) {

--- a/test/spec/test-browser-specific.js
+++ b/test/spec/test-browser-specific.js
@@ -59,7 +59,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads/resuming')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(3)
+      expect(req.requestHeaders['Upload-Offset']).toBe('3')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(11 - 3)
 
@@ -196,7 +196,7 @@ describe('tus', () => {
         expect(req.url).toBe('http://tus.io/uploads/storedUrl')
         expect(req.method).toBe('PATCH')
         expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-        expect(req.requestHeaders['Upload-Offset']).toBe(3)
+        expect(req.requestHeaders['Upload-Offset']).toBe('3')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body.size).toBe(11 - 3)
 
@@ -291,7 +291,7 @@ describe('tus', () => {
         expect(req.url).toBe('http://tus.io/uploads')
         expect(req.method).toBe('POST')
         expect(req.requestHeaders['Upload-Length']).toBe(undefined)
-        expect(req.requestHeaders['Upload-Defer-Length']).toBe(1)
+        expect(req.requestHeaders['Upload-Defer-Length']).toBe('1')
 
         req.respondWith({
           status: 201,
@@ -303,7 +303,7 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/uploads/blargh')
         expect(req.method).toBe('PATCH')
-        expect(req.requestHeaders['Upload-Offset']).toBe(0)
+        expect(req.requestHeaders['Upload-Offset']).toBe('0')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body.length).toBe(11)
 
@@ -320,8 +320,8 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/uploads/blargh')
         expect(req.method).toBe('PATCH')
-        expect(req.requestHeaders['Upload-Offset']).toBe(11)
-        expect(req.requestHeaders['Upload-Length']).toBe(11)
+        expect(req.requestHeaders['Upload-Offset']).toBe('11')
+        expect(req.requestHeaders['Upload-Length']).toBe('11')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body).toBe(null)
 
@@ -369,7 +369,7 @@ describe('tus', () => {
         expect(req.url).toBe('http://tus.io/uploads')
         expect(req.method).toBe('POST')
         expect(req.requestHeaders['Upload-Length']).toBe(undefined)
-        expect(req.requestHeaders['Upload-Defer-Length']).toBe(1)
+        expect(req.requestHeaders['Upload-Defer-Length']).toBe('1')
 
         req.respondWith({
           status: 201,
@@ -381,7 +381,7 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/uploads/blargh')
         expect(req.method).toBe('PATCH')
-        expect(req.requestHeaders['Upload-Offset']).toBe(0)
+        expect(req.requestHeaders['Upload-Offset']).toBe('0')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body.length).toBe(6)
 
@@ -399,7 +399,7 @@ describe('tus', () => {
         expect(req.url).toBe('http://tus.io/uploads/blargh')
         expect(req.method).toBe('PATCH')
         expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-        expect(req.requestHeaders['Upload-Offset']).toBe(6)
+        expect(req.requestHeaders['Upload-Offset']).toBe('6')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body.length).toBe(5)
 
@@ -413,8 +413,8 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/uploads/blargh')
         expect(req.method).toBe('PATCH')
-        expect(req.requestHeaders['Upload-Offset']).toBe(11)
-        expect(req.requestHeaders['Upload-Length']).toBe(11)
+        expect(req.requestHeaders['Upload-Offset']).toBe('11')
+        expect(req.requestHeaders['Upload-Length']).toBe('11')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body).toBe(null)
 
@@ -479,7 +479,7 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/files/foo')
         expect(req.method).toBe('PATCH')
-        expect(req.requestHeaders['Upload-Length']).toBe(11)
+        expect(req.requestHeaders['Upload-Length']).toBe('11')
 
         req.respondWith({
           status: 204,
@@ -551,7 +551,7 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/files/foo')
         expect(req.method).toBe('PATCH')
-        expect(req.requestHeaders['Upload-Length']).toBe(11)
+        expect(req.requestHeaders['Upload-Length']).toBe('11')
 
         req.respondWith({
           status: 204,
@@ -645,7 +645,7 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/files/foo')
         expect(req.method).toBe('PATCH')
-        expect(req.requestHeaders['Upload-Length']).toBe(18)
+        expect(req.requestHeaders['Upload-Length']).toBe('18')
 
         req.respondWith({
           status: 204,
@@ -765,7 +765,7 @@ describe('tus', () => {
         req = await testStack.nextRequest()
         expect(req.url).toBe('http://tus.io/uploads')
         expect(req.method).toBe('POST')
-        expect(req.requestHeaders['Upload-Length']).toBe(11)
+        expect(req.requestHeaders['Upload-Length']).toBe('11')
 
         req.respondWith({
           status: 201,
@@ -778,7 +778,7 @@ describe('tus', () => {
         expect(req.url).toBe('http://tus.io/uploads/blargh')
         expect(req.method).toBe('PATCH')
         expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-        expect(req.requestHeaders['Upload-Offset']).toBe(0)
+        expect(req.requestHeaders['Upload-Offset']).toBe('0')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body.size).toBe(11)
 

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -55,7 +55,7 @@ describe('tus', () => {
       expect(req.method).toBe('POST')
       expect(req.requestHeaders.Custom).toBe('blargh')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(11)
+      expect(req.requestHeaders['Upload-Length']).toBe('11')
       expect(req.requestHeaders['Upload-Metadata']).toBe(
         'foo aGVsbG8=,bar d29ybGQ=,nonlatin c8WCb8WEY2U=,number MTAw',
       )
@@ -75,7 +75,7 @@ describe('tus', () => {
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders.Custom).toBe('blargh')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(11)
 
@@ -117,7 +117,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(11)
+      expect(req.requestHeaders['Upload-Length']).toBe('11')
 
       // The upload URL should be cleared when tus-js.client tries to create a new upload.
       expect(upload.url).toBe(null)
@@ -145,7 +145,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(11)
+      expect(req.requestHeaders['Upload-Length']).toBe('11')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(11)
 
@@ -189,7 +189,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(11)
+      expect(req.requestHeaders['Upload-Length']).toBe('11')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(6)
 
@@ -212,7 +212,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads/blargh')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(6)
+      expect(req.requestHeaders['Upload-Offset']).toBe('6')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(5)
 
@@ -419,7 +419,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(11)
+      expect(req.requestHeaders['Upload-Length']).toBe('11')
 
       req.respondWith({
         status: 201,
@@ -432,7 +432,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads/blargh')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(7)
 
@@ -447,7 +447,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads/blargh')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(7)
+      expect(req.requestHeaders['Upload-Offset']).toBe('7')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(4)
 
@@ -517,7 +517,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(0)
+      expect(req.requestHeaders['Upload-Length']).toBe('0')
 
       req.respondWith({
         status: 201,
@@ -604,7 +604,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/files/upload')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(3)
+      expect(req.requestHeaders['Upload-Offset']).toBe('3')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(11 - 3)
 
@@ -716,7 +716,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/files/upload')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(3)
+      expect(req.requestHeaders['Upload-Offset']).toBe('3')
       expect(req.requestHeaders['X-HTTP-Method-Override']).toBe('PATCH')
 
       req.respondWith({

--- a/test/spec/test-node-specific.js
+++ b/test/spec/test-node-specific.js
@@ -145,7 +145,7 @@ describe('tus', () => {
         fs.writeFileSync(path, 'hello world')
         const file = fs.createReadStream(path)
 
-        const options = {
+      const options = {
           httpStack: new TestHttpStack(),
           endpoint: '/uploads',
           chunkSize: 7,
@@ -178,7 +178,7 @@ describe('tus', () => {
         expect(req.url).toBe('https://tus.io/uploads')
         expect(req.method).toBe('POST')
         expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-        expect(req.requestHeaders['Upload-Length']).toBe(5)
+        expect(req.requestHeaders['Upload-Length']).toBe('5')
         expect(req.requestHeaders['Upload-Concat']).toBe('partial')
 
         req.respondWith({
@@ -192,7 +192,7 @@ describe('tus', () => {
         expect(req.url).toBe('https://tus.io/uploads/upload1')
         expect(req.method).toBe('PATCH')
         expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-        expect(req.requestHeaders['Upload-Offset']).toBe(0)
+        expect(req.requestHeaders['Upload-Offset']).toBe('0')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body.size).toBe(5)
 
@@ -207,7 +207,7 @@ describe('tus', () => {
         expect(req.url).toBe('https://tus.io/uploads')
         expect(req.method).toBe('POST')
         expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-        expect(req.requestHeaders['Upload-Length']).toBe(6)
+        expect(req.requestHeaders['Upload-Length']).toBe('6')
         expect(req.requestHeaders['Upload-Concat']).toBe('partial')
 
         req.respondWith({
@@ -221,7 +221,7 @@ describe('tus', () => {
         expect(req.url).toBe('https://tus.io/uploads/upload2')
         expect(req.method).toBe('PATCH')
         expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-        expect(req.requestHeaders['Upload-Offset']).toBe(0)
+        expect(req.requestHeaders['Upload-Offset']).toBe('0')
         expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
         expect(req.body.size).toBe(6)
 
@@ -367,7 +367,7 @@ describe('tus', () => {
       expect(req.url).toBe('http://tus.io/uploads/resuming')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(3)
+      expect(req.requestHeaders['Upload-Offset']).toBe('3')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(11 - 3)
 
@@ -530,9 +530,9 @@ async function expectHelloWorldUpload(input, options) {
   expect(req.method).toBe('POST')
   if (options.uploadLengthDeferred) {
     expect(req.requestHeaders['Upload-Length']).toBe(undefined)
-    expect(req.requestHeaders['Upload-Defer-Length']).toBe(1)
+    expect(req.requestHeaders['Upload-Defer-Length']).toBe('1')
   } else {
-    expect(req.requestHeaders['Upload-Length']).toBe(11)
+    expect(req.requestHeaders['Upload-Length']).toBe('11')
     expect(req.requestHeaders['Upload-Defer-Length']).toBe(undefined)
   }
 
@@ -546,7 +546,7 @@ async function expectHelloWorldUpload(input, options) {
   req = await options.httpStack.nextRequest()
   expect(req.url).toBe('/uploads/blargh')
   expect(req.method).toBe('PATCH')
-  expect(req.requestHeaders['Upload-Offset']).toBe(0)
+  expect(req.requestHeaders['Upload-Offset']).toBe('0')
   expect(await getBodySize(req.body)).toBe(7)
 
   req.respondWith({
@@ -559,10 +559,10 @@ async function expectHelloWorldUpload(input, options) {
   req = await options.httpStack.nextRequest()
   expect(req.url).toBe('/uploads/blargh')
   expect(req.method).toBe('PATCH')
-  expect(req.requestHeaders['Upload-Offset']).toBe(7)
+  expect(req.requestHeaders['Upload-Offset']).toBe('7')
 
   if (options.uploadLengthDeferred) {
-    expect(req.requestHeaders['Upload-Length']).toBe(11)
+    expect(req.requestHeaders['Upload-Length']).toBe('11')
   }
 
   expect(await getBodySize(req.body)).toBe(4)

--- a/test/spec/test-node-specific.js
+++ b/test/spec/test-node-specific.js
@@ -145,7 +145,7 @@ describe('tus', () => {
         fs.writeFileSync(path, 'hello world')
         const file = fs.createReadStream(path)
 
-      const options = {
+        const options = {
           httpStack: new TestHttpStack(),
           endpoint: '/uploads',
           chunkSize: 7,

--- a/test/spec/test-parallel-uploads.js
+++ b/test/spec/test-parallel-uploads.js
@@ -90,7 +90,7 @@ describe('tus', () => {
       expect(req.method).toBe('POST')
       expect(req.requestHeaders.Custom).toBe('blargh')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(5)
+      expect(req.requestHeaders['Upload-Length']).toBe('5')
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
       expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
 
@@ -106,7 +106,7 @@ describe('tus', () => {
       expect(req.method).toBe('POST')
       expect(req.requestHeaders.Custom).toBe('blargh')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(6)
+      expect(req.requestHeaders['Upload-Length']).toBe('6')
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
       expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
 
@@ -126,7 +126,7 @@ describe('tus', () => {
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders.Custom).toBe('blargh')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(5)
 
@@ -142,7 +142,7 @@ describe('tus', () => {
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders.Custom).toBe('blargh')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(6)
 
@@ -168,7 +168,7 @@ describe('tus', () => {
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders.Custom).toBe('blargh')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(6)
 
@@ -228,7 +228,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(1)
+      expect(req.requestHeaders['Upload-Length']).toBe('1')
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
 
       req.respondWith({
@@ -242,7 +242,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(10)
+      expect(req.requestHeaders['Upload-Length']).toBe('10')
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
 
       req.respondWith({
@@ -257,7 +257,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads/upload1')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(1)
 
@@ -272,7 +272,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads/upload2')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(10)
 
@@ -288,7 +288,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads/upload2')
       expect(req.method).toBe('PATCH')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req.requestHeaders['Upload-Offset']).toBe('0')
       expect(req.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req.body.size).toBe(10)
 
@@ -337,7 +337,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(5)
+      expect(req.requestHeaders['Upload-Length']).toBe('5')
 
       req.respondWith({
         status: 500,
@@ -462,7 +462,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(5)
+      expect(req.requestHeaders['Upload-Length']).toBe('5')
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
       expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
 
@@ -477,7 +477,7 @@ describe('tus', () => {
       expect(req.url).toBe('https://tus.io/uploads')
       expect(req.method).toBe('POST')
       expect(req.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req.requestHeaders['Upload-Length']).toBe(6)
+      expect(req.requestHeaders['Upload-Length']).toBe('6')
       expect(req.requestHeaders['Upload-Concat']).toBe('partial')
       expect(req.requestHeaders['Upload-Metadata']).toBeUndefined()
 
@@ -492,7 +492,7 @@ describe('tus', () => {
       expect(req1.url).toBe('https://tus.io/uploads/upload1')
       expect(req1.method).toBe('PATCH')
       expect(req1.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req1.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req1.requestHeaders['Upload-Offset']).toBe('0')
       expect(req1.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req1.body.size).toBe(5)
 
@@ -500,7 +500,7 @@ describe('tus', () => {
       expect(req2.url).toBe('https://tus.io/uploads/upload2')
       expect(req2.method).toBe('PATCH')
       expect(req2.requestHeaders['Tus-Resumable']).toBe('1.0.0')
-      expect(req2.requestHeaders['Upload-Offset']).toBe(0)
+      expect(req2.requestHeaders['Upload-Offset']).toBe('0')
       expect(req2.requestHeaders['Content-Type']).toBe('application/offset+octet-stream')
       expect(req2.body.size).toBe(6)
 


### PR DESCRIPTION
- Numbers passed as header-values are casted to string type.
- Tests adjusted in a way that expected header values are now strings.