### PR TITLE
Allow `getHeader` methods to return `undefined`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -322,7 +322,7 @@ interface HttpRequest {
     getURL(): string;
 
     setHeader(header: string, value: string);
-    getHeader(header: string);
+    getHeader(header: string): string | undefined;
 
     setProgressHandler((bytesSent: number): void): void;
     // Send the HTTP request with the provided request body. The value of the request body depends
@@ -339,7 +339,7 @@ interface HttpRequest {
 
 interface HttpResponse {
     getStatus(): number;
-    getHeader(header: string): string;
+    getHeader(header: string): string | undefined;
     getBody(): string;
 
     // Return an environment specific object, e.g. the XMLHttpRequest object in browsers.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -106,7 +106,7 @@ export interface HttpRequest {
   getURL(): string
 
   setHeader(header: string, value: string): void
-  getHeader(header: string): string
+  getHeader(header: string): string | undefined
 
   setProgressHandler(handler: (bytesSent: number) => void): void
   send(body: any): Promise<HttpResponse>
@@ -118,7 +118,7 @@ export interface HttpRequest {
 
 export interface HttpResponse {
   getStatus(): number
-  getHeader(header: string): string
+  getHeader(header: string): string | undefined
   getBody(): string
 
   // Return an environment specific object, e.g. the XMLHttpRequest object in browsers.


### PR DESCRIPTION
This PR fixes https://github.com/tus/tus-js-client/issues/706 by updating the type definitions to allow `getHeader` for requests and responses to return `undefined`.