### PR TITLE
Support IETF draft -04 and -05

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -434,7 +434,7 @@ interface SliceResult {
 
 _Default value:_ `'tus-v1'`
 
-tus-js-client uses the [tus v1.0.0 upload protocol](https://tus.io/protocols/resumable-upload) by default. It also includes experimental support for [the draft of Resumable Uploads For HTTP](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/) developed in the HTTP working group of the IETF. By setting the `protocol` option to `'ietf-draft-03'`, tus-js-client will use the protocol as defined in the draft version 03. Please be aware that this feature is experimental and that this option might change in breaking ways in non-major releases.
+tus-js-client uses the [tus v1.0.0 upload protocol](https://tus.io/protocols/resumable-upload) by default. It also includes experimental support for [the draft of Resumable Uploads For HTTP](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/) developed in the HTTP working group of the IETF. By setting the `protocol` option to `'ietf-draft-03'` or `'ietf-draft-05'`, tus-js-client will use the protocol as defined in the draft version 03 or 05 respectively. Please be aware that this feature is experimental and that this option might change in breaking ways in non-major releases.
 
 ## tus.Upload(file, options)
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -177,7 +177,11 @@ class BaseUpload {
       return
     }
 
-    if (![PROTOCOL_TUS_V1, PROTOCOL_IETF_DRAFT_03, PROTOCOL_IETF_DRAFT_05].includes(this.options.protocol)) {
+    if (
+      ![PROTOCOL_TUS_V1, PROTOCOL_IETF_DRAFT_03, PROTOCOL_IETF_DRAFT_05].includes(
+        this.options.protocol,
+      )
+    ) {
       this._emitError(new Error(`tus: unsupported protocol ${this.options.protocol}`))
       return
     }
@@ -597,7 +601,10 @@ class BaseUpload {
       this._offset = 0
       promise = this._addChunkToRequest(req)
     } else {
-      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03 || this.options.protocol === PROTOCOL_IETF_DRAFT_05) {
+      if (
+        this.options.protocol === PROTOCOL_IETF_DRAFT_03 ||
+        this.options.protocol === PROTOCOL_IETF_DRAFT_05
+      ) {
         req.setHeader('Upload-Complete', '?0')
       }
       promise = this._sendRequest(req, null)
@@ -837,7 +844,10 @@ class BaseUpload {
         return this._sendRequest(req)
       }
 
-      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03 || this.options.protocol === PROTOCOL_IETF_DRAFT_05) {
+      if (
+        this.options.protocol === PROTOCOL_IETF_DRAFT_03 ||
+        this.options.protocol === PROTOCOL_IETF_DRAFT_05
+      ) {
         req.setHeader('Upload-Complete', done ? '?1' : '?0')
       }
       this._emitProgress(this._offset, this._size)

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -6,6 +6,7 @@ import uuid from './uuid.js'
 
 const PROTOCOL_TUS_V1 = 'tus-v1'
 const PROTOCOL_IETF_DRAFT_03 = 'ietf-draft-03'
+const PROTOCOL_IETF_DRAFT_05 = 'ietf-draft-05'
 
 const defaultOptions = {
   endpoint: null,
@@ -176,7 +177,7 @@ class BaseUpload {
       return
     }
 
-    if (![PROTOCOL_TUS_V1, PROTOCOL_IETF_DRAFT_03].includes(this.options.protocol)) {
+    if (![PROTOCOL_TUS_V1, PROTOCOL_IETF_DRAFT_03, PROTOCOL_IETF_DRAFT_05].includes(this.options.protocol)) {
       this._emitError(new Error(`tus: unsupported protocol ${this.options.protocol}`))
       return
     }
@@ -596,7 +597,7 @@ class BaseUpload {
       this._offset = 0
       promise = this._addChunkToRequest(req)
     } else {
-      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03) {
+      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03 || this.options.protocol === PROTOCOL_IETF_DRAFT_05) {
         req.setHeader('Upload-Complete', '?0')
       }
       promise = this._sendRequest(req, null)
@@ -791,7 +792,11 @@ class BaseUpload {
       this._emitProgress(start + bytesSent, this._size)
     })
 
-    req.setHeader('Content-Type', 'application/offset+octet-stream')
+    if (this.options.protocol === PROTOCOL_TUS_V1) {
+      req.setHeader('Content-Type', 'application/offset+octet-stream')
+    } else if (this.options.protocol === PROTOCOL_IETF_DRAFT_05) {
+      req.setHeader('Content-Type', 'application/partial-upload')
+    }
 
     // The specified chunkSize may be Infinity or the calcluated end position
     // may exceed the file's size. In both cases, we limit the end position to
@@ -832,7 +837,7 @@ class BaseUpload {
         return this._sendRequest(req)
       }
 
-      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03) {
+      if (this.options.protocol === PROTOCOL_IETF_DRAFT_03 || this.options.protocol === PROTOCOL_IETF_DRAFT_05) {
         req.setHeader('Upload-Complete', done ? '?1' : '?0')
       }
       this._emitProgress(this._offset, this._size)
@@ -968,6 +973,8 @@ function openRequest(method, url, options) {
 
   if (options.protocol === PROTOCOL_IETF_DRAFT_03) {
     req.setHeader('Upload-Draft-Interop-Version', '5')
+  } else if (options.protocol === PROTOCOL_IETF_DRAFT_05) {
+    req.setHeader('Upload-Draft-Interop-Version', '6')
   } else {
     req.setHeader('Tus-Resumable', '1.0.0')
   }


### PR DESCRIPTION
Support for [-04](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/04/) and [-05](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/05/). All changes can be seen in https://www.ietf.org/archive/id/draft-ietf-httpbis-resumable-upload-05.html#name-changes, but the relevant changes for tus-js-client are minimal and basically boil down to setting the new `Content-Type` header. We already set `Upload-Length` in POST requests, which has also been defined in -05 now.