### PR TITLE
Set Upload-Length when appropriate

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -108,7 +108,10 @@ class BaseUpload {
 
     // An array of upload URLs which are used for uploading the different
     // parts, if the parallelUploads option is used.
-    this._parallelUploadUrls = null
+    this._parallelUploadUrls = null    
+
+    // The remote upload resource's length is deferred
+    this._deferred = false
   }
 
   /**
@@ -586,6 +589,7 @@ class BaseUpload {
 
     if (this.options.uploadLengthDeferred) {
       req.setHeader('Upload-Defer-Length', '1')
+      this._deferred = true
     } else {
       req.setHeader('Upload-Length', `${this._size}`)
     }
@@ -704,9 +708,13 @@ class BaseUpload {
           return
         }
 
+        const deferLength = Number.parseInt(res.getHeader("Upload-Defer-Length"), 10)
+        this._deferred = deferLength === 1
+
         const length = Number.parseInt(res.getHeader('Upload-Length'), 10)
         if (
           Number.isNaN(length) &&
+          !this._deferred &&
           !this.options.uploadLengthDeferred &&
           this.options.protocol === PROTOCOL_TUS_V1
         ) {
@@ -821,9 +829,10 @@ class BaseUpload {
       // If the upload length is deferred, the upload size was not specified during
       // upload creation. So, if the file reader is done reading, we know the total
       // upload size and can tell the tus server.
-      if (this.options.uploadLengthDeferred && done) {
+      if (this._deferred && (!this.options.uploadLengthDeferred || done)) {
         this._size = this._offset + valueSize
         req.setHeader('Upload-Length', `${this._size}`)
+        this._deferred = false
       }
 
       // The specified uploadSize might not match the actual amount of data that a source


### PR DESCRIPTION
This PR fixes issue #182 where user cannot upload against a deferred resource.

The 2 main changes are:
1. Bypass the `Upload-Length` header check if `Upload-Defer-Length` exists in the HEAD response
2. Sets the `Upload-Length` header in the next request if `options.uploadLengthDeferred` is false - because we would know the length straight away

The code is mostly taken from the relevant issue, so credits goes there. But I've also modified it slightly to simplify the logic.

Closes #182 