### PR TITLE
Avoid default exports in favour of named exports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
     "rules": {
       "style": {
         "noParameterAssign": "warn",
-        "noDefaultExport": "warn",
+        "noDefaultExport": "error",
         "useCollapsedElseIf": "error",
         "useNodejsImportProtocol": "off"
       },

--- a/demos/reactnative/App.js
+++ b/demos/reactnative/App.js
@@ -17,6 +17,7 @@ const styles = StyleSheet.create({
   },
 })
 
+// biome-ignore lint/style/noDefaultExport: React Native uses default exports
 export default class App extends React.Component {
   constructor() {
     super()

--- a/lib/browser/fileReader.ts
+++ b/lib/browser/fileReader.ts
@@ -1,16 +1,16 @@
 import { isReactNativeFile, isReactNativePlatform } from './isReactNative.js'
-import uriToBlob from './uriToBlob.js'
+import { uriToBlob } from './uriToBlob.js'
 
 import type { FileReader, FileSource, UploadInput } from '../options.js'
-import BlobFileSource from './sources/BlobFileSource.js'
-import StreamFileSource from './sources/StreamFileSource.js'
+import { BlobFileSource } from './sources/BlobFileSource.js'
+import { StreamFileSource } from './sources/StreamFileSource.js'
 
 function isWebStream(input: UploadInput): input is Pick<ReadableStreamDefaultReader, 'read'> {
   return 'read' in input && typeof input.read === 'function'
 }
 
 // TODO: Make sure that we support ArrayBuffers, TypedArrays, DataViews and Blobs
-export default class BrowserFileReader implements FileReader {
+export class BrowserFileReader implements FileReader {
   async openFile(input: UploadInput, chunkSize: number): Promise<FileSource> {
     // In React Native, when user selects a file, instead of a File or Blob,
     // you usually get a file object {} with a uri property that contains

--- a/lib/browser/fileSignature.ts
+++ b/lib/browser/fileSignature.ts
@@ -4,7 +4,7 @@ import { isReactNativeFile, isReactNativePlatform } from './isReactNative.js'
 /**
  * Generate a fingerprint for a file which will be used the store the endpoint
  */
-export default function fingerprint(file: UploadInput, options: UploadOptions) {
+export function fingerprint(file: UploadInput, options: UploadOptions) {
   if (isReactNativePlatform() && isReactNativeFile(file)) {
     return Promise.resolve(reactNativeFingerprint(file, options))
   }

--- a/lib/browser/httpStack.ts
+++ b/lib/browser/httpStack.ts
@@ -1,6 +1,6 @@
 import type { HttpProgressHandler, HttpRequest, HttpResponse, HttpStack } from '../options.js'
 
-export default class XHRHttpStack implements HttpStack {
+export class XHRHttpStack implements HttpStack {
   createRequest(method, url) {
     return new XHRRequest(method, url)
   }

--- a/lib/browser/index.ts
+++ b/lib/browser/index.ts
@@ -1,12 +1,12 @@
-import DetailedError from '../error.js'
+import { DetailedError } from '../error.js'
 import { enableDebugLog } from '../logger.js'
-import NoopUrlStorage from '../noopUrlStorage.js'
+import { NoopUrlStorage } from '../noopUrlStorage.js'
 import type { UploadInput, UploadOptions } from '../options.js'
-import BaseUpload, { terminate, defaultOptions as baseDefaultOptions } from '../upload.js'
+import { BaseUpload, defaultOptions as baseDefaultOptions, terminate } from '../upload.js'
 
-import BrowserFileReader from './fileReader.js'
-import fingerprint from './fileSignature.js'
-import DefaultHttpStack from './httpStack.js'
+import { BrowserFileReader } from './fileReader.js'
+import { fingerprint } from './fileSignature.js'
+import { XHRHttpStack as DefaultHttpStack } from './httpStack.js'
 import { WebStorageUrlStorage, canStoreURLs } from './urlStorage.js'
 
 const defaultOptions = {

--- a/lib/browser/sources/BlobFileSource.ts
+++ b/lib/browser/sources/BlobFileSource.ts
@@ -1,8 +1,8 @@
 import type { FileSource, SliceResult } from '../../options.js'
-import isCordova from './isCordova.js'
-import readAsByteArray from './readAsByteArray.js'
+import { isCordova } from './isCordova.js'
+import { readAsByteArray } from './readAsByteArray.js'
 
-export default class BlobFileSource implements FileSource {
+export class BlobFileSource implements FileSource {
   _file: Blob
 
   size: number

--- a/lib/browser/sources/StreamFileSource.ts
+++ b/lib/browser/sources/StreamFileSource.ts
@@ -26,7 +26,7 @@ function concat<T extends StreamFileSource['_buffer']>(a: T, b: T): T {
   throw new Error('Unknown data type')
 }
 
-export default class StreamFileSource implements FileSource {
+export class StreamFileSource implements FileSource {
   _reader: Pick<ReadableStreamDefaultReader<StreamFileSource['_buffer']>, 'read'>
 
   _buffer: Blob | Uint8Array | number[] | undefined

--- a/lib/browser/sources/isCordova.ts
+++ b/lib/browser/sources/isCordova.ts
@@ -2,4 +2,4 @@ const isCordova = () =>
   typeof window !== 'undefined' &&
   ('PhoneGap' in window || 'Cordova' in window || 'cordova' in window)
 
-export default isCordova
+export { isCordova }

--- a/lib/browser/sources/readAsByteArray.ts
+++ b/lib/browser/sources/readAsByteArray.ts
@@ -5,7 +5,7 @@
  */
 // TODO: Reconsider whether this is a sensible approach or whether we cause
 // high memory usage with `chunkSize` is unset.
-export default function readAsByteArray(chunk: Blob): Promise<Uint8Array> {
+export function readAsByteArray(chunk: Blob): Promise<Uint8Array> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = () => {

--- a/lib/browser/uriToBlob.ts
+++ b/lib/browser/uriToBlob.ts
@@ -3,7 +3,7 @@
  * React Native to retrieve a file (identified by a file://
  * URI) as a blob.
  */
-export default function uriToBlob(uri: string): Promise<Blob> {
+export function uriToBlob(uri: string): Promise<Blob> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
     xhr.responseType = 'blob'

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -1,6 +1,6 @@
 import type { HttpRequest, HttpResponse } from './options.js'
 
-class DetailedError extends Error {
+export class DetailedError extends Error {
   originalRequest?: HttpRequest
 
   originalResponse?: HttpResponse
@@ -29,5 +29,3 @@ class DetailedError extends Error {
     this.message = message
   }
 }
-
-export default DetailedError

--- a/lib/node/fileReader.ts
+++ b/lib/node/fileReader.ts
@@ -2,15 +2,15 @@ import { ReadStream } from 'fs'
 import isStream from 'is-stream'
 
 import type { FileReader, UploadInput } from '../options.js'
-import BufferSource from './sources/BufferFileSource.js'
-import getFileSource from './sources/NodeFileSource.js'
-import StreamFileSource from './sources/StreamFileSource.js'
+import { BufferFileSource } from './sources/BufferFileSource.js'
+import { getFileSource } from './sources/NodeFileSource.js'
+import { StreamFileSource } from './sources/StreamFileSource.js'
 
-export default class NodeFileReader implements FileReader {
+export class NodeFileReader implements FileReader {
   // TODO: Use async here and less Promise.resolve
   openFile(input: UploadInput, chunkSize: number) {
     if (Buffer.isBuffer(input)) {
-      return Promise.resolve(new BufferSource(input))
+      return Promise.resolve(new BufferFileSource(input))
     }
 
     if (input instanceof ReadStream && input.path != null) {

--- a/lib/node/fileSignature.ts
+++ b/lib/node/fileSignature.ts
@@ -3,16 +3,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import type { UploadInput, UploadOptions } from '../options.js'
 
-/**
- * Generate a fingerprint for a file which will be used the store the endpoint
- *
- * @param {File} file
- * @param {Object} options
- */
-export default function fingerprint(
-  file: UploadInput,
-  options: UploadOptions,
-): Promise<string | null> {
+export function fingerprint(file: UploadInput, options: UploadOptions): Promise<string | null> {
   if (Buffer.isBuffer(file)) {
     // create MD5 hash for buffer type
     const blockSize = 64 * 1024 // 64kb

--- a/lib/node/httpStack.ts
+++ b/lib/node/httpStack.ts
@@ -8,7 +8,7 @@ import throttle from 'lodash.throttle'
 import type { HttpProgressHandler, HttpRequest, HttpResponse, HttpStack } from '../options.js'
 import type { FileSliceTypes } from './index.js'
 
-export default class NodeHttpStack implements HttpStack {
+export class NodeHttpStack implements HttpStack {
   private _requestOptions: http.RequestOptions
 
   constructor(requestOptions: http.RequestOptions = {}) {

--- a/lib/node/index.ts
+++ b/lib/node/index.ts
@@ -1,15 +1,15 @@
 import type { ReadStream } from 'node:fs'
 import type { Readable } from 'node:stream'
-import DetailedError from '../error.js'
+import { DetailedError } from '../error.js'
 import { enableDebugLog } from '../logger.js'
-import NoopUrlStorage from '../noopUrlStorage.js'
+import { NoopUrlStorage } from '../noopUrlStorage.js'
 import type { UploadInput, UploadOptions } from '../options.js'
-import BaseUpload, { terminate, defaultOptions as baseDefaultOptions } from '../upload.js'
+import { BaseUpload, defaultOptions as baseDefaultOptions, terminate } from '../upload.js'
 
-import NodeFileReader from './fileReader.js'
-import fingerprint from './fileSignature.js'
-import DefaultHttpStack from './httpStack.js'
-import StreamFileSource from './sources/StreamFileSource.js'
+import { NodeFileReader } from './fileReader.js'
+import { fingerprint } from './fileSignature.js'
+import { NodeHttpStack as DefaultHttpStack } from './httpStack.js'
+import { StreamFileSource } from './sources/StreamFileSource.js'
 import { FileUrlStorage, canStoreURLs } from './urlStorage.js'
 
 const defaultOptions = {
@@ -49,5 +49,6 @@ export {
   enableDebugLog,
   DefaultHttpStack,
   DetailedError,
+  // TODO: Remove `as`
   StreamFileSource as StreamSource,
 }

--- a/lib/node/sources/BufferFileSource.ts
+++ b/lib/node/sources/BufferFileSource.ts
@@ -1,6 +1,6 @@
 import type { FileSource } from '../../options.js'
 
-export default class BufferFileSource implements FileSource {
+export class BufferFileSource implements FileSource {
   size: number
 
   private _buffer: Buffer

--- a/lib/node/sources/NodeFileSource.ts
+++ b/lib/node/sources/NodeFileSource.ts
@@ -1,7 +1,7 @@
 import { type ReadStream, createReadStream, promises as fsPromises } from 'fs'
 import type { FileSource } from '../../options.js'
 
-export default async function getFileSource(stream: ReadStream): Promise<NodeFileSource> {
+export async function getFileSource(stream: ReadStream): Promise<NodeFileSource> {
   const path = stream.path.toString()
   const { size } = await fsPromises.stat(path)
 
@@ -23,7 +23,7 @@ export default async function getFileSource(stream: ReadStream): Promise<NodeFil
   return new NodeFileSource(stream, path, actualSize)
 }
 
-class NodeFileSource implements FileSource {
+export class NodeFileSource implements FileSource {
   size: number
 
   _stream: ReadStream

--- a/lib/node/sources/StreamFileSource.ts
+++ b/lib/node/sources/StreamFileSource.ts
@@ -44,7 +44,7 @@ async function readChunk(stream: Readable, size: number) {
  * Note that it is forbidden to call with startB < startA or startB > endA. In other words,
  * the slice calls cannot seek back and must not skip data from the stream.
  */
-export default class StreamFileSource implements FileSource {
+export class StreamFileSource implements FileSource {
   // Setting the size to null indicates that we have no calculation available
   // for how much data this stream will emit requiring the user to specify
   // it manually (see the `uploadSize` option).

--- a/lib/noopUrlStorage.ts
+++ b/lib/noopUrlStorage.ts
@@ -1,6 +1,6 @@
 import type { PreviousUpload, UrlStorage } from './options.js'
 
-export default class NoopUrlStorage implements UrlStorage {
+export class NoopUrlStorage implements UrlStorage {
   findAllUploads() {
     return Promise.resolve([])
   }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,6 +1,6 @@
 import type { ReadStream } from 'node:fs'
 import type { Readable } from 'node:stream'
-import type DetailedError from './error.js'
+import type { DetailedError } from './error.js'
 
 export const PROTOCOL_TUS_V1 = 'tus-v1'
 export const PROTOCOL_IETF_DRAFT_03 = 'ietf-draft-03'

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1,6 +1,6 @@
 import { Base64 } from 'js-base64'
 import URL from 'url-parse'
-import DetailedError from './error.js'
+import { DetailedError } from './error.js'
 import { log } from './logger.js'
 import {
   type FileSource,
@@ -14,7 +14,7 @@ import {
   type UploadOptions,
   type UrlStorage,
 } from './options.js'
-import uuid from './uuid.js'
+import { uuid } from './uuid.js'
 
 export const defaultOptions = {
   endpoint: null,
@@ -54,7 +54,7 @@ export const defaultOptions = {
   protocol: PROTOCOL_TUS_V1 as UploadOptions['protocol'],
 }
 
-export default class BaseUpload {
+export class BaseUpload {
   options: UploadOptions
 
   // The storage module used to store URLs

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -10,7 +10,7 @@
  *
  * @return {string} The generate UUID
  */
-export default function uuid(): string {
+export function uuid(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0
     const v = c === 'x' ? r : (r & 0x3) | 0x8


### PR DESCRIPTION
For an explanation, see https://github.com/isaacs/tshy?tab=readme-ov-file#handling-default-exports.