### PR TITLE
Use `undefined` instead of `null` as default values for options

### DIFF
--- a/lib/browser/urlStorage.ts
+++ b/lib/browser/urlStorage.ts
@@ -12,7 +12,7 @@ try {
   const key = 'tusSupport'
   const originalValue = localStorage.getItem(key)
   localStorage.setItem(key, String(originalValue))
-  if (originalValue === null) localStorage.removeItem(key)
+  if (originalValue == null) localStorage.removeItem(key)
 } catch (e: unknown) {
   // If we try to access localStorage inside a sandboxed iframe, a SecurityError
   // is thrown. When in private mode on iOS Safari, a QuotaExceededError is

--- a/lib/node/httpStack.ts
+++ b/lib/node/httpStack.ts
@@ -119,7 +119,7 @@ class Request implements HttpRequest {
   }
 
   abort() {
-    if (this._request !== null) this._request.abort()
+    if (this._request != null) this._request.abort()
     return Promise.resolve()
   }
 

--- a/lib/node/sources/StreamFileSource.ts
+++ b/lib/node/sources/StreamFileSource.ts
@@ -21,7 +21,7 @@ async function readChunk(stream: Readable, size: number) {
       // TODO: Node requires size to be less than 1GB. Add a validation for that
       const chunk = stream.read(size)
 
-      if (chunk !== null) {
+      if (chunk != null) {
         stream.off('error', onError)
         stream.off('readable', onReadable)
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -32,36 +32,31 @@ export type UploadInput =
   | ReactNativeFile
 
 export interface UploadOptions {
-  // TODO: Embrace undefined over null
-  endpoint: string | null
+  endpoint?: string
 
-  uploadUrl: string | null
+  uploadUrl?: string
   metadata: { [key: string]: string }
   metadataForPartialUploads: UploadOptions['metadata']
   fingerprint: (file: UploadInput, options: UploadOptions) => Promise<string | null>
-  uploadSize: number | null
+  uploadSize?: number
 
-  onProgress: ((bytesSent: number, bytesTotal: number | null) => void) | null
-  onChunkComplete:
-    | ((chunkSize: number, bytesAccepted: number, bytesTotal: number | null) => void)
-    | null
-  onSuccess: ((payload: OnSuccessPayload) => void) | null
-  onError: ((error: Error | DetailedError) => void) | null
-  onShouldRetry:
-    | ((error: DetailedError, retryAttempt: number, options: UploadOptions) => boolean)
-    | null
-  onUploadUrlAvailable: (() => void) | null
+  onProgress?: (bytesSent: number, bytesTotal: number | null) => void
+  onChunkComplete?: (chunkSize: number, bytesAccepted: number, bytesTotal: number | null) => void
+  onSuccess?: (payload: OnSuccessPayload) => void
+  onError?: (error: Error | DetailedError) => void
+  onShouldRetry?: (error: DetailedError, retryAttempt: number, options: UploadOptions) => boolean
+  onUploadUrlAvailable?: () => void
 
   overridePatchMethod: boolean
   headers: { [key: string]: string }
   addRequestId: boolean
-  onBeforeRequest: ((req: HttpRequest) => void | Promise<void>) | null
-  onAfterResponse: ((req: HttpRequest, res: HttpResponse) => void | Promise<void>) | null
+  onBeforeRequest?: (req: HttpRequest) => void | Promise<void>
+  onAfterResponse?: (req: HttpRequest, res: HttpResponse) => void | Promise<void>
 
   chunkSize: number
   retryDelays: number[]
   parallelUploads: number
-  parallelUploadBoundaries: { start: number; end: number }[] | null
+  parallelUploadBoundaries?: { start: number; end: number }[]
   storeFingerprintForResuming: boolean
   removeFingerprintOnSuccess: boolean
   uploadLengthDeferred: boolean


### PR DESCRIPTION
`undefined` communicates the absence of a value better than `null`, which indicates that a value was explicitly set to an empty value. In addition, it makes the code a bit ligther by allowing us to use the optional operator `?` instead of having to add `| null` frequently.