### PR TITLE
Utilize `async`/`await` more frequently

### DIFF
--- a/lib/browser/BrowserFileReader.ts
+++ b/lib/browser/BrowserFileReader.ts
@@ -35,26 +35,22 @@ export class BrowserFileReader implements FileReader {
     // TODO: Consider turning Blobs, Buffers, and Uint8Arrays into a single type.
     // Potentially handling it in the same way as in Node.js
     if (input instanceof Blob) {
-      return Promise.resolve(new BlobFileSource(input))
+      return new BlobFileSource(input)
     }
 
     if (isWebStream(input)) {
       chunkSize = Number(chunkSize)
       if (!Number.isFinite(chunkSize)) {
-        return Promise.reject(
-          new Error(
-            'cannot create source for stream without a finite value for the `chunkSize` option',
-          ),
+        throw new Error(
+          'cannot create source for stream without a finite value for the `chunkSize` option',
         )
       }
 
-      return Promise.resolve(new StreamFileSource(input))
+      return new StreamFileSource(input)
     }
 
-    return Promise.reject(
-      new Error(
-        'source object may only be an instance of File, Blob, or Reader in this environment',
-      ),
+    throw new Error(
+      'source object may only be an instance of File, Blob, or Reader in this environment',
     )
   }
 }

--- a/lib/browser/sources/BlobFileSource.ts
+++ b/lib/browser/sources/BlobFileSource.ts
@@ -21,14 +21,14 @@ export class BlobFileSource implements FileSource {
       const size = value.length
       const done = end >= this.size
 
-      return Promise.resolve({ value, size, done })
+      return { value, size, done }
     }
 
     const value = this._file.slice(start, end)
     const size = value.size
     const done = end >= this.size
 
-    return Promise.resolve({ value, size, done })
+    return { value, size, done }
   }
 
   close() {

--- a/lib/browser/urlStorage.ts
+++ b/lib/browser/urlStorage.ts
@@ -69,6 +69,7 @@ export class WebStorageUrlStorage implements UrlStorage {
       }
 
       try {
+        // TODO: Validate JSON
         const upload = JSON.parse(item)
         upload.urlStorageKey = key
 

--- a/lib/node/NodeHttpStack.ts
+++ b/lib/node/NodeHttpStack.ts
@@ -76,6 +76,7 @@ class Request implements HttpRequest {
         },
       }
 
+      // TODO: What to do here?
       // @ts-expect-error We still have to type `size` for `body`
       if (body?.size) {
         // @ts-expect-error We still have to type `size` for `body`

--- a/lib/node/fileSignature.ts
+++ b/lib/node/fileSignature.ts
@@ -1,36 +1,30 @@
 import { createHash } from 'node:crypto'
-import * as fs from 'node:fs'
+import { ReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import * as path from 'node:path'
 import type { UploadInput, UploadOptions } from '../options.js'
 
-export function fingerprint(file: UploadInput, options: UploadOptions): Promise<string | null> {
+export async function fingerprint(
+  file: UploadInput,
+  options: UploadOptions,
+): Promise<string | null> {
   if (Buffer.isBuffer(file)) {
     // create MD5 hash for buffer type
     const blockSize = 64 * 1024 // 64kb
     const content = file.slice(0, Math.min(blockSize, file.length))
     const hash = createHash('md5').update(content).digest('hex')
     const ret = ['node-buffer', hash, file.length, options.endpoint].join('-')
-    return Promise.resolve(ret)
+    return ret
   }
 
-  if (file instanceof fs.ReadStream && file.path != null) {
-    return new Promise((resolve, reject) => {
-      const name = path.resolve(
-        Buffer.isBuffer(file.path) ? file.path.toString('utf-8') : file.path,
-      )
-      fs.stat(file.path, (err, info) => {
-        if (err) {
-          reject(err)
-          return
-        }
+  if (file instanceof ReadStream && file.path != null) {
+    const name = path.resolve(Buffer.isBuffer(file.path) ? file.path.toString('utf-8') : file.path)
+    const info = await stat(file.path)
+    const ret = ['node-file', name, info.size, info.mtime.getTime(), options.endpoint].join('-')
 
-        const ret = ['node-file', name, info.size, info.mtime.getTime(), options.endpoint].join('-')
-
-        resolve(ret)
-      })
-    })
+    return ret
   }
 
   // fingerprint cannot be computed for file input type
-  return Promise.resolve(null)
+  return null
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -45,7 +45,7 @@ export interface UploadOptions {
   onSuccess?: (payload: OnSuccessPayload) => void
   onError?: (error: Error | DetailedError) => void
   onShouldRetry?: (error: DetailedError, retryAttempt: number, options: UploadOptions) => boolean
-  onUploadUrlAvailable?: () => void
+  onUploadUrlAvailable?: () => void | Promise<void>
 
   overridePatchMethod: boolean
   headers: { [key: string]: string }

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -1013,15 +1013,18 @@ describe('tus', () => {
 
       expect(options.onShouldRetry).toHaveBeenCalled()
       const args1 = options.onShouldRetry.calls.argsFor(0)
-      expect(args1[0].message).toEqual('tus: unexpected response while creating upload, originated from request (method: POST, url: http://tus.io/files/, response code: 500, response text: , request id: n/a)')
+      expect(args1[0].message).toEqual(
+        'tus: unexpected response while creating upload, originated from request (method: POST, url: http://tus.io/files/, response code: 500, response text: , request id: n/a)',
+      )
       expect(args1[1]).toEqual(0)
       expect(args1[2]).toEqual(upload.options)
 
       const args2 = options.onShouldRetry.calls.argsFor(1)
-      expect(args2[0].message).toEqual('tus: unexpected response while uploading chunk, originated from request (method: PATCH, url: http://tus.io/files/foo, response code: 423, response text: , request id: n/a)')
+      expect(args2[0].message).toEqual(
+        'tus: unexpected response while uploading chunk, originated from request (method: PATCH, url: http://tus.io/files/foo, response code: 423, response text: , request id: n/a)',
+      )
       expect(args2[1]).toEqual(1)
       expect(args2[2]).toEqual(upload.options)
-
     })
 
     // This tests ensures that tus-js-client correctly aborts if the

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -934,7 +934,6 @@ describe('tus', () => {
       }
 
       spyOn(options, 'onShouldRetry').and.callThrough()
-      spyOn(Upload.prototype, '_emitError').and.callThrough()
 
       const upload = new Upload(file, options)
       upload.start()
@@ -1012,11 +1011,17 @@ describe('tus', () => {
       await options.onSuccess.toBeCalled
       expect(options.onSuccess).toHaveBeenCalled()
 
-      const [error1] = upload._emitError.calls.argsFor(0)
       expect(options.onShouldRetry).toHaveBeenCalled()
-      expect(options.onShouldRetry.calls.argsFor(0)).toEqual([error1, 0, upload.options])
-      const [error2] = upload._emitError.calls.argsFor(1)
-      expect(options.onShouldRetry.calls.argsFor(1)).toEqual([error2, 1, upload.options])
+      const args1 = options.onShouldRetry.calls.argsFor(0)
+      expect(args1[0].message).toEqual('tus: unexpected response while creating upload, originated from request (method: POST, url: http://tus.io/files/, response code: 500, response text: , request id: n/a)')
+      expect(args1[1]).toEqual(0)
+      expect(args1[2]).toEqual(upload.options)
+
+      const args2 = options.onShouldRetry.calls.argsFor(1)
+      expect(args2[0].message).toEqual('tus: unexpected response while uploading chunk, originated from request (method: PATCH, url: http://tus.io/files/foo, response code: 423, response text: , request id: n/a)')
+      expect(args2[1]).toEqual(1)
+      expect(args2[2]).toEqual(upload.options)
+
     })
 
     // This tests ensures that tus-js-client correctly aborts if the

--- a/test/spec/test-node-specific.js
+++ b/test/spec/test-node-specific.js
@@ -157,7 +157,8 @@ describe('tus', () => {
         await expectHelloWorldUpload(file, options)
       })
 
-      it('should support parallelUploads and fs.ReadStream', async () => {
+      it('should support parallelUploads', async () => {
+        // TODO: The ordering of requests is no longer deterministic, so we need to update this test
         // Create a temporary file
         const path = temp.path()
         fs.writeFileSync(path, 'hello world')


### PR DESCRIPTION
Previously, the core uploading logic "manually" handled promises using `.then` and `.catch`. This PR transitions to using `await` and `try {} catch {}` where possible. The benefit is that this allows us to improve the error handling. The main uploading logic can now just throw errors, that will bubble up to the entry function, which takes care of inspecting the error and issuing retries.