### PR TITLE
Replace `fs.ReadStream`-centric handling with more generic `PathReference`

### DIFF
--- a/demos/nodejs/index.js
+++ b/demos/nodejs/index.js
@@ -1,8 +1,7 @@
-import { createReadStream } from 'node:fs'
 import { Upload } from 'tus-js-client'
 
 const path = `${import.meta.dirname}/../../README.md`
-const file = createReadStream(path)
+const file = { path }
 
 const options = {
   endpoint: 'https://tusd.tusdemo.net/files/',

--- a/lib/node/NodeFileReader.ts
+++ b/lib/node/NodeFileReader.ts
@@ -1,18 +1,27 @@
-import { ReadStream } from 'node:fs'
+import { createReadStream } from 'node:fs'
 import isStream from 'is-stream'
 
 import {
   openFile as openBaseFile,
   supportedTypes as supportedBaseTypes,
 } from '../commonFileReader.js'
-import type { FileReader, UploadInput } from '../options.js'
-import { getFileSource } from './sources/NodeFileSource.js'
+import type { FileReader, PathReference, UploadInput } from '../options.js'
 import { NodeStreamFileSource } from './sources/NodeStreamFileSource.js'
+import { getFileSourceFromPath } from './sources/PathFileSource.js'
+
+function isPathReference(input: UploadInput): input is PathReference {
+  return (
+    typeof input === 'object' &&
+    input !== null &&
+    'path' in input &&
+    (typeof input.path === 'string' || Buffer.isBuffer(input.path))
+  )
+}
 
 export class NodeFileReader implements FileReader {
   openFile(input: UploadInput, chunkSize: number) {
-    if (input instanceof ReadStream && input.path != null) {
-      return getFileSource(input)
+    if (isPathReference(input)) {
+      return getFileSourceFromPath(input)
     }
 
     if (isStream.readable(input)) {
@@ -32,4 +41,20 @@ export class NodeFileReader implements FileReader {
       `in this environment the source object may only be an instance of: ${supportedBaseTypes.join(', ')}, fs.ReadStream (Node.js), stream.Readable (Node.js)`,
     )
   }
+}
+
+/**
+ * This (unused) function is a simple test to ensure that fs.ReadStreams
+ * satisfy the PathReference interface. In the past, tus-js-client explicitly
+ * accepted fs.ReadStreams and included it in its type definitions.
+ *
+ * Since tus-js-client v5, we have moved away from only accepting fs.ReadStream
+ * in favor of a more generic PathReference. This function ensures that the definition
+ * of PathReference includes fs.ReadStream. If this wasn't the case, the TypeScript
+ * compiler would complain during the build step, making this a poor-man's type test.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: see above
+function testFsReadStreamAsPathReference() {
+  const pathReference: PathReference = createReadStream('test.txt')
+  new NodeFileReader().openFile(pathReference, 1024)
 }

--- a/lib/node/index.ts
+++ b/lib/node/index.ts
@@ -3,7 +3,7 @@ import type { Readable } from 'node:stream'
 import { DetailedError } from '../DetailedError.js'
 import { NoopUrlStorage } from '../NoopUrlStorage.js'
 import { enableDebugLog } from '../logger.js'
-import type { UploadInput, UploadOptions } from '../options.js'
+import type { PathReference, UploadInput, UploadOptions } from '../options.js'
 import { BaseUpload, defaultOptions as baseDefaultOptions, terminate } from '../upload.js'
 
 import { canStoreURLs } from './FileUrlStorage.js'
@@ -25,7 +25,8 @@ export type FileTypes =
   | ArrayBufferView
   | Blob
   | Readable
-  | ReadStream
+  | PathReference
+
 export type FileSliceTypes = ArrayBuffer | SharedArrayBuffer | ArrayBufferView | Blob | ReadStream
 
 class Upload extends BaseUpload {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,4 +1,3 @@
-import type { ReadStream } from 'node:fs'
 import type { Readable } from 'node:stream'
 import type { DetailedError } from './DetailedError.js'
 
@@ -6,16 +5,34 @@ export const PROTOCOL_TUS_V1 = 'tus-v1'
 export const PROTOCOL_IETF_DRAFT_03 = 'ietf-draft-03'
 export const PROTOCOL_IETF_DRAFT_05 = 'ietf-draft-05'
 
-// ReactNativeFile describes the structure that is returned from the
-// Expo image picker (see https://docs.expo.dev/versions/latest/sdk/imagepicker/)
-// TODO: Should these properties be fileName and fileSize instead?
-// TODO: What about other file pickers without Expo?
-// TODO: Should this be renamed to Expo?
+/**
+ * ReactNativeFile describes the structure that is returned from the
+ * Expo image picker (see https://docs.expo.dev/versions/latest/sdk/imagepicker/)
+ * TODO: Should these properties be fileName and fileSize instead?
+ * TODO: What about other file pickers without Expo?
+ * TODO: Should this be renamed to Expo?
+ * TODO: Only size is relevant for us. Not the rest.
+ */
 export interface ReactNativeFile {
   uri: string
   name?: string
   size?: string
   exif?: Record<string, unknown>
+}
+
+/**
+ * PathReference is a reference to a file on disk. Currently, it's only supported
+ * in Node.js. It can be supplied as a normal object or as an instance of `fs.ReadStream`,
+ * which also statisfies this interface.
+ *
+ * Optionally, a start and/or end position can be defined to define a range of bytes from
+ * the file that should be uploaded instead of the entire file. Both start and end are
+ * inclusive and start counting at 0, similar to the options accepted by `fs.createReadStream`.
+ */
+export interface PathReference {
+  path: string | Buffer
+  start?: number
+  end?: number
 }
 
 export type UploadInput =
@@ -29,8 +46,7 @@ export type UploadInput =
   | Pick<ReadableStreamDefaultReader, 'read'>
   // Buffer, stream.Readable, fs.ReadStream are available in Node.js
   | Readable // TODO: Replace this with our own interface based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3634b01d50c10ce1afaae63e41d39e7da309d8e3/types/node/globals.d.ts#L399
-  | ReadStream // TODO: Replace this with { path: string, start: number?, end: number? }
-  // ReactNativeFile is intended for React Native apps
+  | PathReference
   | ReactNativeFile
 
 export interface UploadOptions {


### PR DESCRIPTION
In all current tus-js-client versions, the only way to upload a file on disk in Node.js without loading the entire content into a Buffer is to create an fs.ReadStream and pass it to the Upload constructor. While this might make sense in the beginning, it's actually pretty useless since tus-js-client doesn't use the stream at all to read the file. Instead, it inspects the fs.ReadStream's path property and uses it when opening new fs.ReadStreams for each PATCH request.

This allows tus-js-client to effortlessly seek to previous positions without buffering when the upload is interrupted and has to be resumed. However, requiring our users to first create an fs.ReadStream, which then basically thrown away by tus-js-client is not a good approach.

Hence, this PR changes how files can be uploaded in Node.js. Instead of testing specifically for fs.ReadStream, tus-js-client will now accept a more generic object that matches a PathReference interface, which is basically just an object with a `path` property and optional start/end positions (see `lib/options.ts`). The interface has been designed to match fs.ReadStream, so existing integrations with tus-js-client won't break due to this PR.

However, the new interface allows users to also upload files by just giving tus-js-client the path:

```js
import { Upload } from 'tus-js-client'

const file = { path: 'path/to/my/file.txt' }

const options = {
  endpoint: 'https://tusd.tusdemo.net/files/',
}

const upload = new Upload(file, options)
upload.start()
```