### PR TITLE
Type results of slicing and HTTP request content

### DIFF
--- a/lib/browser/FetchHttpStack.ts
+++ b/lib/browser/FetchHttpStack.ts
@@ -1,4 +1,11 @@
-import type { HttpProgressHandler, HttpRequest, HttpResponse, HttpStack } from '../options.js'
+import { readable as isNodeReadableStream } from 'is-stream'
+import type {
+  HttpProgressHandler,
+  HttpRequest,
+  HttpResponse,
+  HttpStack,
+  SliceType,
+} from '../options.js'
 
 // TODO: Add tests for this.
 export class FetchHttpStack implements HttpStack {
@@ -42,7 +49,13 @@ class FetchRequest implements HttpRequest {
     // The Fetch API currently does not expose a way to track upload progress.
   }
 
-  async send(body?: Blob): Promise<FetchResponse> {
+  async send(body?: SliceType): Promise<FetchResponse> {
+    if (isNodeReadableStream(body)) {
+      throw new Error(
+        'Using a Node.js readable stream as HTTP request body is not supported using the Fetch API HTTP stack.',
+      )
+    }
+
     const res = await fetch(this._url, {
       method: this._method,
       headers: this._headers,

--- a/lib/browser/XHRHttpStack.ts
+++ b/lib/browser/XHRHttpStack.ts
@@ -1,4 +1,11 @@
-import type { HttpProgressHandler, HttpRequest, HttpResponse, HttpStack } from '../options.js'
+import { readable as isNodeReadableStream } from 'is-stream'
+import type {
+  HttpProgressHandler,
+  HttpRequest,
+  HttpResponse,
+  HttpStack,
+  SliceType,
+} from '../options.js'
 
 export class XHRHttpStack implements HttpStack {
   createRequest(method: string, url: string): HttpRequest {
@@ -58,8 +65,13 @@ class XHRRequest implements HttpRequest {
     }
   }
 
-  // TODO: Validate the type of body
-  send(body?: Blob): Promise<HttpResponse> {
+  send(body?: SliceType): Promise<HttpResponse> {
+    if (isNodeReadableStream(body)) {
+      throw new Error(
+        'Using a Node.js readable stream as HTTP request body is not supported using the XMLHttpRequest HTTP stack.',
+      )
+    }
+
     return new Promise((resolve, reject) => {
       this._xhr.onload = () => {
         resolve(new XHRResponse(this._xhr))

--- a/lib/node/index.ts
+++ b/lib/node/index.ts
@@ -1,9 +1,7 @@
-import type { ReadStream } from 'node:fs'
-import type { Readable } from 'node:stream'
 import { DetailedError } from '../DetailedError.js'
 import { NoopUrlStorage } from '../NoopUrlStorage.js'
 import { enableDebugLog } from '../logger.js'
-import type { PathReference, UploadInput, UploadOptions } from '../options.js'
+import type { UploadInput, UploadOptions } from '../options.js'
 import { BaseUpload, defaultOptions as baseDefaultOptions, terminate } from '../upload.js'
 
 import { canStoreURLs } from './FileUrlStorage.js'
@@ -18,16 +16,6 @@ const defaultOptions = {
   urlStorage: new NoopUrlStorage(),
   fingerprint,
 }
-
-export type FileTypes =
-  | ArrayBuffer
-  | SharedArrayBuffer
-  | ArrayBufferView
-  | Blob
-  | Readable
-  | PathReference
-
-export type FileSliceTypes = ArrayBuffer | SharedArrayBuffer | ArrayBufferView | Blob | ReadStream
 
 class Upload extends BaseUpload {
   constructor(file: UploadInput, options: Partial<UploadOptions> = {}) {

--- a/lib/node/sources/PathFileSource.ts
+++ b/lib/node/sources/PathFileSource.ts
@@ -35,6 +35,8 @@ export class PathFileSource implements FileSource {
   }
 
   slice(start: number, end: number) {
+    // TODO: Does this create multiple file descriptors? Can we reduce this by
+    // using a file handle instead?
     // The path reference might be configured to not read from the beginning,
     // but instead start at a different offset. The start value from the caller
     // does not include the offset, so we need to add this offset to our range later.

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -12,6 +12,7 @@ import {
   PROTOCOL_IETF_DRAFT_05,
   PROTOCOL_TUS_V1,
   type PreviousUpload,
+  type SliceType,
   type UploadInput,
   type UploadOptions,
 } from './options.js'
@@ -981,7 +982,7 @@ export class BaseUpload {
    *
    * @api private
    */
-  _sendRequest(req: HttpRequest, body?: unknown): Promise<HttpResponse> {
+  _sendRequest(req: HttpRequest, body?: SliceType): Promise<HttpResponse> {
     return sendRequest(req, body, this.options)
   }
 }
@@ -1041,7 +1042,7 @@ function openRequest(method: string, url: string, options: UploadOptions): HttpR
  */
 async function sendRequest(
   req: HttpRequest,
-  body: unknown | undefined,
+  body: SliceType | undefined,
   options: UploadOptions,
 ): Promise<HttpResponse> {
   if (typeof options.onBeforeRequest === 'function') {


### PR DESCRIPTION
The return value for the data in `FileSource#slice` is currently typed as unknown. As is the request content argument for `HttpRequest#send`. The original idea behind leaving them unknown is to accommodate platform-specific types (e.g. Buffer in Node.js). However, this leads to confusion in the implementations about what types have to be handled in the HTTP stack.

This PR adds proper types, so implementations know what types must be expected, creating more waterproof types.