### PR TITLE
Drop support for Node.js 18, test on Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
             suite: 'browserstack'
           - desc: 'Puppeteer'
             suite: 'puppeteer'
-          - desc: 'Node.js 18'
-            suite: 'node'
-            node: 18
           - desc: 'Node.js 20'
             suite: 'node'
             node: 20
+          - desc: 'Node.js 22'
+            suite: 'node'
+            node: 22
     name: Tests (${{ matrix.desc }})
     steps:
       - name: Check out sources
@@ -66,7 +66,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node || 20 }}
+          node-version: ${{ matrix.node || 22 }}
       - name: Install dependencies
         uses: sergioramos/yarn-actions/install@v6
         with:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,7 @@ who provide their great service glady for Open Source project for free.
 
 ## Node.js support
 
-tus-js-client is tested and known to work in Node.js v18 or newer.
+tus-js-client is tested and known to work in Node.js v20 or newer.
 
 Since Node's environment is quite different than a browser's runtime and
 provides other capabilities but also restrictions, tus-js-client will have a

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "files": ["lib/", "lib.cjs/", "lib.esm/", "dist/", "node/", "browser/"],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node.js 18 reached its EOL in a few days (2025-04-30, https://github.com/nodejs/release#release-schedule). When tough it's not holding tus-js-client's development back, let's drop support for it in the upcoming v5 major release before we run into problems.

This PR also modifies CI to test on Node.js 22.