### PR TITLE
Accept stream instances instead of readers

### DIFF
--- a/demos/browser/video.html
+++ b/demos/browser/video.html
@@ -62,6 +62,6 @@
     </div>
   </body>
 
-  <script src="../../dist/tus.js"></script>
+  <script src="../../../dist/tus.js"></script>
   <script src="./video.js"></script>
 </html>

--- a/docs/api.md
+++ b/docs/api.md
@@ -224,7 +224,7 @@ A boolean indicating if the fingerprint in the URL storage will be removed once 
 
 _Default value:_ `false`
 
-A boolean indicating whether a stream of data is going to be uploaded as a [`Reader`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader). If so, the total size isn't available when we begin uploading, so we use the Tus [`Upload-Defer-Length`](https://tus.io/protocols/resumable-upload.html#upload-defer-length) header. Once the reader is finished, the total file size is sent to the tus server in order to complete the upload. Furthermore, `chunkSize` must be set to a finite number. See the `/demos/browser/video.js` file for an example of how to use this property.
+A boolean indicating whether a stream of data is going to be uploaded as a [`Reader`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream). If so, the total size isn't available when we begin uploading, so we use the Tus [`Upload-Defer-Length`](https://tus.io/protocols/resumable-upload.html#upload-defer-length) header. Once the reader is finished, the total file size is sent to the tus server in order to complete the upload. Furthermore, `chunkSize` must be set to a finite number. See the `/demos/browser/video.js` file for an example of how to use this property.
 
 #### uploadDataDuringCreation
 
@@ -442,7 +442,7 @@ The constructor for the `tus.Upload` class. The upload will not be started autom
 
 Depending on the platform, the `file` argument must be an instance of the following types:
 
-- inside browser: `File`, `Blob`, or [`Reader`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader)
+- inside browser: `File`, `Blob`, or [`Reader`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
 - inside Node.js: `Buffer` or `Readable` stream
 - inside Cordova: `File` object from a `FileEntry` (see [demo](/demos/cordova/www/js/index.js))
 - inside React Native: Object with uri property: `{ uri: 'file:///...', ... }` (see [installation notes](/docs/installation.md#react-native-support) and [demo](/demos/reactnative/App.js))

--- a/lib/commonFileReader.ts
+++ b/lib/commonFileReader.ts
@@ -1,7 +1,7 @@
 import type { FileSource, UploadInput } from './options.js'
 import { ArrayBufferViewFileSource } from './sources/ArrayBufferViewFileSource.js'
 import { BlobFileSource } from './sources/BlobFileSource.js'
-import { WebStreamFileSource, isWebStream } from './sources/WebStreamFileSource.js'
+import { WebStreamFileSource } from './sources/WebStreamFileSource.js'
 
 /**
  * openFile provides FileSources for input types that have to be handled in all environments,
@@ -33,7 +33,7 @@ export function openFile(input: UploadInput, chunkSize: number): FileSource | nu
     return new ArrayBufferViewFileSource(view)
   }
 
-  if (isWebStream(input)) {
+  if (input instanceof ReadableStream) {
     chunkSize = Number(chunkSize)
     if (!Number.isFinite(chunkSize)) {
       throw new Error(
@@ -53,5 +53,5 @@ export const supportedTypes = [
   'ArrayBuffer',
   'SharedArrayBuffer',
   'ArrayBufferView',
-  'ReadableStreamDefaultReader (Web Streams)',
+  'ReadableStream (Web Streams)',
 ]

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -41,8 +41,7 @@ export type UploadInput =
   | ArrayBuffer
   | SharedArrayBuffer
   | ArrayBufferView // includes Node.js' Buffer
-  // TODO: We should accept a ReadableStream instead of a reader
-  | Pick<ReadableStreamDefaultReader, 'read'>
+  | ReadableStream // Web Streams
   // available in Node.js
   | NodeReadableStream
   | PathReference


### PR DESCRIPTION
Readable streams in the Web Streams API are composed of the actual stream object and a separate reader object. This is different than Node.js streams, where they are combined into one object.

Currently the `Upload` constructor will accept instances of `ReadableStreamDefaultReader`, i.e. the reader and not the actual stream. I'm considering switching this to take the actual stream instance (`ReadableStream`) and then obtain a reader internally.

This would align tus-js-client closer with how the Fetch API accepts streams as request content. 