### PR TITLE
Emit errors when request is aborted

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -350,6 +350,9 @@ interface HttpRequest {
     // - in browsers: a TypedArray, a DataView a Blob, or null.
     // - in  Node.js: a Buffer, a ReadableStream, or null.
     send(body: any): Promise<HttpResponse>;
+
+    // Aborts the request if it's currently in progress. If so, `send` should reject
+    // with an error of type DOMException, with name AbortError.
     abort(): Promise<void>;
 
     // Return an environment specific object, e.g. the XMLHttpRequest object in browsers.

--- a/lib/browser/FetchHttpStack.ts
+++ b/lib/browser/FetchHttpStack.ts
@@ -68,6 +68,7 @@ class FetchRequest implements HttpRequest {
   }
 
   abort(): Promise<void> {
+    // Note: When abort() is called, the fetch() promise rejects with an Error of type DOMException, with name AbortError.
     this._controller.abort()
     return Promise.resolve()
   }

--- a/lib/browser/XHRHttpStack.ts
+++ b/lib/browser/XHRHttpStack.ts
@@ -81,11 +81,16 @@ class XHRRequest implements HttpRequest {
         reject(err)
       }
 
+      this._xhr.onabort = () => {
+        reject(new DOMException('Request was aborted', 'AbortError'))
+      }
+
       this._xhr.send(body)
     })
   }
 
   abort(): Promise<void> {
+    // Note: Calling abort() triggers the `abort` event, but no `error` event.
     this._xhr.abort()
     return Promise.resolve()
   }

--- a/lib/node/NodeHttpStack.ts
+++ b/lib/node/NodeHttpStack.ts
@@ -146,7 +146,9 @@ class Request implements HttpRequest {
   }
 
   abort() {
-    if (this._request != null) this._request.abort()
+    // Note: The destroy() method will trigger an `error` event with the provided error.
+    if (this._request != null)
+      this._request.destroy(new DOMException('Request was aborted', 'AbortError'))
     return Promise.resolve()
   }
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -155,6 +155,9 @@ export interface HttpRequest {
   setProgressHandler(handler: HttpProgressHandler): void
   // TODO: Should this be something like { value: unknown, size: number }?
   send(body?: SliceType): Promise<HttpResponse>
+
+  // Aborts the request if it's currently in progress. If so, `send` should reject
+  // with an error of type DOMException, with name AbortError.
   abort(): Promise<void>
 
   // Return an environment specific object, e.g. the XMLHttpRequest object in browsers.


### PR DESCRIPTION
While working on https://github.com/tus/tus-js-client/pull/775, we discovered that not every HTTP stack in tus-js-client behaves the same way when aborting requests:

- XHRHttpStack just leaves the promise returned by `send` hanging, neither resolving nor rejecting it.
- NodeHttpStack threw a network-related error (usually ECONNRESET).
- FetchHttpStack threw a DOMException.

While the exact error is not important, it's helpful to standardize on throwing some error, as allows for simpler logic when aborting requests. Hence this PR, which implements this. It uses a DOMException since normal Error instances in JavaScript don't have proper error codes. While DOMException is a Web API, I think it's available in most JavaScript runtimes.