### PR TITLE
Fix: retryable error on final chunk request fails deferred length uploads

### DIFF
--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -868,7 +868,6 @@ export class BaseUpload {
     if (this._uploadLengthDeferred && done) {
       this._size = this._offset + sizeOfValue
       req.setHeader('Upload-Length', `${this._size}`)
-      this._uploadLengthDeferred = false
     }
 
     // The specified uploadSize might not match the actual amount of data that a source


### PR DESCRIPTION
I noticed while testing out retry behavior on a deferred length upload that if the final chunk request received a retryable error response from the server, the retry would fail due to a missing `Upload-Length` header and the upload would not be recoverable. I was able to stably reproduce the issue by pointing to a local tusd server set to 409 whenever the `Upload-Length` header was present.

As far as I can tell, nothing hangs on `this._uploadLengthDeferred` being set to `false` on the final chunk request, and it's necessary for it to be present on a retry so the retry gains the `Upload-Length` header, so the simplest solution is just to remove this line.