### PR TITLE
WIP: Make Header Indexing Case-Insensitive in tus Client

### DIFF
--- a/lib/browser/FetchHttpStack.ts
+++ b/lib/browser/FetchHttpStack.ts
@@ -93,7 +93,7 @@ class FetchResponse implements HttpResponse {
   }
 
   getHeader(header: string): string | undefined {
-    return this._res.headers.get(header) || undefined
+    return this._res.headers.get(header) || this._res.headers.get(header.toLowerCase()) || undefined
   }
 
   getBody(): string {

--- a/lib/browser/XHRHttpStack.ts
+++ b/lib/browser/XHRHttpStack.ts
@@ -112,7 +112,11 @@ class XHRResponse implements HttpResponse {
   }
 
   getHeader(header: string): string | undefined {
-    return this._xhr.getResponseHeader(header) || undefined
+    return (
+      this._xhr.getResponseHeader(header) ||
+      this._xhr.getResponseHeader(header.toLowerCase()) ||
+      undefined
+    )
   }
 
   getBody(): string {

--- a/test/spec/helpers/utils.js
+++ b/test/spec/helpers/utils.js
@@ -184,7 +184,9 @@ export class TestResponse {
   }
 
   getHeader(header) {
-    return this._response.responseHeaders[header]
+    return (
+      this._response.responseHeaders[header] || this._response.responseHeaders[header.toLowerCase()]
+    )
   }
 
   getBody() {


### PR DESCRIPTION
I realize this may be somewhat contentious, but I wanted to start with a workable solution before opening the discussion.

According to the HTTP/1.1 specification, header field names are case-insensitive, while in HTTP/2 they are required to be lowercase.

Currently, the tus client relies on case-sensitive indexing of headers, which causes issues in environments where backend stacks normalize headers to lowercase — a behavior already adopted by many frameworks and servers.

This PR introduces support for case-insensitive header lookups by normalizing header keys to lowercase when performing lookups.


---

⚙️ Summary

- Ensures compatibility with HTTP/1.1 and HTTP/2 expectations

- Fixes issues in backend setups where headers are automatically rewritten to lowercase

- Aligns tus client behavior with common practice across HTTP client and server libraries


---

💬 Feedback Welcome


If there’s another approach the maintainers would prefer, please let me know — I’m happy to adjust the implementation to align with your preferred style or design direction.