### PR TITLE
Wrap errors thrown in user callbacks with descriptive messages

### DIFF
--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -494,7 +494,12 @@ export class BaseUpload {
     if (this._aborted) return
 
     if (typeof this.options.onError === 'function') {
-      this.options.onError(err)
+      try {
+        this.options.onError(err)
+      } catch (callbackErr) {
+        const causeMsg = callbackErr instanceof Error ? callbackErr.message : String(callbackErr)
+        throw new Error(`tus: error thrown in 'onError' callback: ${causeMsg}`)
+      }
     } else {
       throw err
     }
@@ -558,7 +563,12 @@ export class BaseUpload {
    */
   private _emitProgress(bytesSent: number, bytesTotal: number | null): void {
     if (typeof this.options.onProgress === 'function') {
-      this.options.onProgress(bytesSent, bytesTotal)
+      try {
+        this.options.onProgress(bytesSent, bytesTotal)
+      } catch (err) {
+        const causeMsg = err instanceof Error ? err.message : String(err)
+        throw new Error(`tus: error thrown in 'onProgress' callback: ${causeMsg}`)
+      }
     }
   }
 
@@ -577,7 +587,13 @@ export class BaseUpload {
     bytesTotal: number | null,
   ): void {
     if (typeof this.options.onChunkComplete === 'function') {
-      this.options.onChunkComplete(chunkSize, bytesAccepted, bytesTotal)
+      try {
+        this.options.onChunkComplete(chunkSize, bytesAccepted, bytesTotal)
+      } catch (err) {
+
+        const causeMsg = err instanceof Error ? err.message : String(err)
+        throw new Error(`tus: error thrown in 'onChunkComplete' callback: ${causeMsg}`)
+      }
     }
   }
 
@@ -628,7 +644,7 @@ export class BaseUpload {
       if (!(err instanceof Error)) {
         throw new Error(`tus: value thrown that is not an error: ${err}`)
       }
-
+      
       throw new DetailedError('tus: failed to create upload', err, req, undefined)
     }
 
@@ -1056,13 +1072,23 @@ async function sendRequest(
   options: UploadOptions,
 ): Promise<HttpResponse> {
   if (typeof options.onBeforeRequest === 'function') {
-    await options.onBeforeRequest(req)
+    try {
+      await options.onBeforeRequest(req)
+    } catch (err) {
+      const causeMsg = err instanceof Error ? err.message : String(err)
+      throw new Error(`tus: error thrown in 'onBeforeRequest' callback: ${causeMsg}`)
+    }
   }
 
   const res = await req.send(body)
 
   if (typeof options.onAfterResponse === 'function') {
-    await options.onAfterResponse(req, res)
+    try {
+      await options.onAfterResponse(req, res)
+    } catch (err) {
+      const causeMsg = err instanceof Error ? err.message : String(err)
+      throw new Error(`tus: error thrown in 'onAfterResponse' callback: ${causeMsg}`)
+    }
   }
 
   return res
@@ -1117,7 +1143,12 @@ function shouldRetry(
   }
 
   if (options && typeof options.onShouldRetry === 'function') {
-    return options.onShouldRetry(err, retryAttempt, options)
+    try {
+      return options.onShouldRetry(err, retryAttempt, options)
+    } catch (callbackErr) {
+      const causeMsg = callbackErr instanceof Error ? callbackErr.message : String(callbackErr)
+      throw new Error(`tus: error thrown in 'onShouldRetry' callback: ${causeMsg}`)
+    }
   }
 
   return defaultOnShouldRetry(err)

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1132,11 +1132,15 @@ function shouldRetry(
   // - the error is server error (i.e. not a status 4xx except a 409 or 423) or
   // a onShouldRetry is specified and returns true
   // - the browser does not indicate that we are offline
+  const isCallbackError =
+    err.message.includes('tus: error thrown in') && err.message.includes('callback')
   const isNetworkError = 'originalRequest' in err && err.originalRequest != null
   if (
     options.retryDelays == null ||
     retryAttempt >= options.retryDelays.length ||
-    !isNetworkError
+    !isNetworkError ||
+    // do not retry if callback function throws Error
+    isCallbackError
   ) {
     return false
   }

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -590,7 +590,6 @@ export class BaseUpload {
       try {
         this.options.onChunkComplete(chunkSize, bytesAccepted, bytesTotal)
       } catch (err) {
-
         const causeMsg = err instanceof Error ? err.message : String(err)
         throw new Error(`tus: error thrown in 'onChunkComplete' callback: ${causeMsg}`)
       }
@@ -644,7 +643,7 @@ export class BaseUpload {
       if (!(err instanceof Error)) {
         throw new Error(`tus: value thrown that is not an error: ${err}`)
       }
-      
+
       throw new DetailedError('tus: failed to create upload', err, req, undefined)
     }
 

--- a/test/spec/test-common.js
+++ b/test/spec/test-common.js
@@ -267,6 +267,75 @@ describe('tus', () => {
       expect(err.originalResponse).toBeDefined()
     })
 
+    it('should wrap error thrown in onChunkComplete callback', async () => {
+      const testStack = new TestHttpStack()
+      const file = getBlob('hello world')
+      const options = {
+        httpStack: testStack,
+        endpoint: 'http://tus.io/uploads',
+        retryDelays: [10, 10, 10],
+        onChunkComplete() {
+          throw new Error('something went wrong in callback')
+        },
+        onError: waitableFunction('onError'),
+      }
+
+      const upload = new Upload(file, options)
+      upload.start()
+
+      let req = await testStack.nextRequest()
+      expect(req.method).toBe('POST')
+
+      req.respondWith({
+        status: 201,
+        responseHeaders: {
+          Location: 'http://tus.io/uploads/blargh',
+        },
+      })
+
+      req = await testStack.nextRequest()
+      expect(req.method).toBe('PATCH')
+      req.respondWith({
+        status: 204,
+        responseHeaders: {
+          'Upload-Offset': '11',
+        },
+      })
+
+      const err = await options.onError.toBeCalled()
+      expect(err.message).toContain("error thrown in 'onChunkComplete' callback")
+      expect(err.message).toContain('something went wrong in callback')
+
+      // Verify no retry happened even though retryDelays is set
+      const nextReq = await Promise.race([testStack.nextRequest(), wait(200)])
+      expect(nextReq).toBe('timed out')
+    })
+
+    it('should wrap errors thrown in onBeforeRequest callback', async () => {
+      const testStack = new TestHttpStack()
+      const file = getBlob('hello world')
+      const options = {
+        httpStack: testStack,
+        endpoint: 'http://tus.io/uploads',
+        retryDelays: [10, 10, 10],
+        onBeforeRequest() {
+          throw new Error('something went wrong in onBeforeRequest')
+        },
+        onError: waitableFunction('onError'),
+      }
+
+      const upload = new Upload(file, options)
+      upload.start()
+
+      const err = await options.onError.toBeCalled()
+      expect(err.message).toContain("error thrown in 'onBeforeRequest' callback")
+      expect(err.message).toContain('something went wrong in onBeforeRequest')
+
+      // no retry for callback errors
+      const nextReq = await Promise.race([testStack.nextRequest(), wait(200)])
+      expect(nextReq).toBe('timed out')
+    })
+
     it('should invoke the request and response callbacks', async () => {
       const testStack = new TestHttpStack()
       const file = getBlob('hello world')


### PR DESCRIPTION
Fixes #294

When a user's callback (onProgress,  onError, onChunkComplete, onBeforeRequest, onAfterResponse, onShouldRetry) throws an error, the error  message now clearly indicates which callback caused it instead of appearing  as an internal tus error. 