### PR TITLE
fix: upload stalls with deferred length when size is multiple of chunkSize

### DIFF
--- a/lib/node/sources/NodeStreamFileSource.ts
+++ b/lib/node/sources/NodeStreamFileSource.ts
@@ -12,9 +12,22 @@ import type { FileSource } from '../../options.js'
  */
 function readChunk(stream: Readable, size: number) {
   return new Promise<Buffer>((resolve, reject) => {
+    // If the stream has already ended, resolve immediately with an empty buffer.
+    if (stream.readableEnded) {
+      resolve(Buffer.alloc(0))
+      return
+    }
+
     const onError = (err: Error) => {
       stream.off('readable', onReadable)
+      stream.off('end', onEnd)
       reject(err)
+    }
+
+    const onEnd = () => {
+      stream.off('error', onError)
+      stream.off('readable', onReadable)
+      resolve(Buffer.alloc(0))
     }
 
     const onReadable = () => {
@@ -24,12 +37,14 @@ function readChunk(stream: Readable, size: number) {
       if (chunk != null) {
         stream.off('error', onError)
         stream.off('readable', onReadable)
+        stream.off('end', onEnd)
 
         resolve(chunk)
       }
     }
 
     stream.once('error', onError)
+    stream.once('end', onEnd)
     stream.on('readable', onReadable)
   })
 }


### PR DESCRIPTION
Fixes #779

## Problem

When using `uploadLengthDeferred: true` with a Node.js stream whose total size is exactly divisible by `chunkSize`, the upload hangs forever after the last chunk.

**Root cause:** After consuming the last aligned chunk, `readChunk()` is called again. The stream has no more data and emits `end`, but `readChunk` only listens for `readable` events — the promise never resolves.

### Timeline

1. `slice(0, 7)` → reads 7 bytes, `done: false`
2. `slice(7, 14)` → reads 7 bytes, stream buffer depleted, `done: false`
3. `slice(14, 21)` → buffer empty, `readChunk()` called → **hangs** (stream emits `end`, not `readable`)

## Fix

- Add `end` event listener in `readChunk()` that resolves with an empty buffer
- Add `readableEnded` guard at entry for already-ended streams
- Clean up all three listeners (`error`, `readable`, `end`) on resolution