### PR TITLE
Pin third-party GitHub Actions to SHAs and install Puppeteer Chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: ${{ matrix.node || 24 }}
       - name: Install Deno
         if: matrix.suite == 'deno'
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
         with:
           deno-version: latest
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     env:
-      PUPPETEER_CACHE_DIR: ${{ runner.temp }}/puppeteer
+      PUPPETEER_CACHE_DIR: /tmp/puppeteer-cache
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +44,9 @@ jobs:
         run: npm ci
       - name: Install Chrome for Puppeteer
         if: matrix.suite == 'puppeteer'
-        run: npx puppeteer browsers install chrome
+        run: |
+          rm -rf "$PUPPETEER_CACHE_DIR"
+          npx puppeteer browsers install chrome
       - name: Build
         run: npm run build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
         run: npm ci
       - name: Verify Chrome for Puppeteer
         if: matrix.suite == 'puppeteer'
-        run: "$CHROME_BIN" --version
+        run: |
+          "$CHROME_BIN" --version
       - name: Build
         run: npm run build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     env:
-      PUPPETEER_CACHE_DIR: /tmp/puppeteer-cache
+      CHROME_BIN: /usr/bin/google-chrome
     strategy:
       fail-fast: false
       matrix:
@@ -42,11 +42,9 @@ jobs:
           deno-version: latest
       - name: Install dependencies
         run: npm ci
-      - name: Install Chrome for Puppeteer
+      - name: Verify Chrome for Puppeteer
         if: matrix.suite == 'puppeteer'
-        run: |
-          rm -rf "$PUPPETEER_CACHE_DIR"
-          npx puppeteer browsers install chrome
+        run: "$CHROME_BIN" --version
       - name: Build
         run: npm run build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    env:
+      PUPPETEER_CACHE_DIR: ${{ runner.temp }}/puppeteer
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           deno-version: latest
       - name: Install dependencies
         run: npm ci
+      - name: Install Chrome for Puppeteer
+        if: matrix.suite == 'puppeteer'
+        run: npx puppeteer browsers install chrome
       - name: Build
         run: npm run build
       - name: Test

--- a/test/karma/puppeteer.conf.cjs
+++ b/test/karma/puppeteer.conf.cjs
@@ -2,7 +2,7 @@
 const baseConfig = require('./base.conf.cjs')
 
 // Configure to use Puppeteer. See https://github.com/karma-runner/karma-chrome-launcher#available-browsers
-process.env.CHROME_BIN = require('puppeteer').executablePath()
+process.env.CHROME_BIN = process.env.CHROME_BIN || require('puppeteer').executablePath()
 
 module.exports = (config) => {
   baseConfig(config)


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.
- Added an explicit Puppeteer Chrome install step backed by a fresh `/tmp/puppeteer-cache` so the browser test job does not rely on a pre-populated or partially populated runner cache.

Changed workflows:

- `.github/workflows/ci.yml`

Resolved refs:

- `denoland/setup-deno@v2` -> `denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows
- Observed the first CI run fail because Chrome was missing for Puppeteer; added an explicit install step and re-pushed

Follow-up update:

- Set `PUPPETEER_CACHE_DIR` to `${{ runner.temp }}/puppeteer` after CI found a partial default Puppeteer cache.

Follow-up update:

- Replaced the invalid job-level `runner.temp` expression with `/tmp/puppeteer-cache` and clear it before installing Chrome.

Follow-up update:

- Made the Karma Puppeteer config respect `CHROME_BIN` and pointed CI at the runner system Chrome, avoiding Puppeteer cache/install brittleness.
