### PR TITLE
docs: explain proxy body-size limits and how to pick a chunkSize

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -143,7 +143,7 @@ A number indicating the maximum size of a `PATCH` request body in bytes. The def
 **Warning:** **Do not set this value**, unless you are being forced to. The only two valid reasons for setting `chunkSize` are:
 
 - You are passing a reader or readable stream as input to tus-js-client and it will complain that it "cannot create source for stream without a finite value for the chunkSize option" if you leave `chunkSize` empty.
-- You are using a tus server or proxy with a limit on how big request bodies may be.
+- You are using a tus server or proxy with a limit on how big request bodies may be. For example, Cloudflare's proxy caps request bodies at 100 MB on Free and Pro plans (200 MB on Business), and Nginx defaults to a 1 MB `client_max_body_size`. With the default `chunkSize` of `Infinity`, the entire file is sent in a single `PATCH` request, so uploads larger than such a limit fail (typically with `HTTP 413`, but some proxies reset the connection instead) even though the tus server itself would accept them. In that case, set `chunkSize` safely below the smallest body-size limit in your chain (for example, 50-90 MB behind Cloudflare) while respecting any server-side minimums (see below).
 
 In all other cases, **do not set this value** as it will hurt your upload performance. If in doubt, leave this value to the default or contact us for help.
 


### PR DESCRIPTION
The `chunkSize` documentation already lists "a tus server or proxy with a limit on how big request bodies may be" as one of the two valid reasons for setting the option, but it does not describe what actually happens when you hit such a limit, nor which value to pick.

We ran into this in production: uploads behind a proxy failed with a 413 status code for larger files, and nothing pointed towards `chunkSize` as the cause. With the default of `Infinity` the whole file goes into a single `PATCH` request, and the proxy rejects it before the tus server ever sees it. Raising the origin's own body limits does not help, because the proxy caps the request first.

This PR expands that one bullet with the mechanism, the symptom (a 413, or a closed connection), and the guidance to pick a chunk size below the smallest body-size limit on the path to the server, while respecting server-side minimums (the S3 note that already follows).

Following the review, the vendor names and their current limits are gone. Only the concept remains.

No code changes.
