### PR TITLE
Make tus-js-client usable in a Service Worker

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -370,6 +370,34 @@ interface HttpResponse {
 
 ```
 
+##### FetchHttpStack
+
+Browsers ship two implementations. The default, `XHRHttpStack`, is built on `XMLHttpRequest` and reports upload progress. `FetchHttpStack` is built on the Fetch API and works where `XMLHttpRequest` does not exist — most notably inside a service worker:
+
+```js
+import { Upload } from 'tus-js-client'
+import { FetchHttpStack } from 'tus-js-client/browser/FetchHttpStack'
+
+const upload = new Upload(file, {
+  endpoint: '/files',
+  httpStack: new FetchHttpStack(),
+  chunkSize: 512 * 1024,
+})
+```
+
+Two differences from `XHRHttpStack` are worth knowing:
+
+- `setProgressHandler` is a no-op, because the Fetch API exposes no upload progress. `onProgress` still fires once per completed `PATCH` request, so a finite `chunkSize` is what determines how granular progress is.
+- Node.js readable streams are not supported as a request body.
+
+`FetchHttpStack` accepts an optional `timeout`, in milliseconds:
+
+```js
+new FetchHttpStack({ timeout: 30000 })
+```
+
+The Fetch API has no timeout of its own, so without one a request that stalls without erroring is never resolved nor rejected. A request cancelled by the timeout rejects with a `TimeoutError` `DOMException`, which is distinguishable from the `AbortError` that `abort()` produces.
+
 #### urlStorage
 
 _Default value:_ Environment-specific implementation

--- a/lib/browser/FetchHttpStack.ts
+++ b/lib/browser/FetchHttpStack.ts
@@ -7,10 +7,27 @@ import type {
   SliceType,
 } from '../options.js'
 
-// TODO: Add tests for this.
+export interface FetchHttpStackOptions {
+  /**
+   * Milliseconds to wait for a request to complete before it is aborted. The
+   * Fetch API has no timeout of its own, so without this a request that stalls
+   * without erroring is never resolved nor rejected. Defaults to no timeout.
+   *
+   * A request cancelled this way rejects with a `TimeoutError` DOMException,
+   * which is distinguishable from the `AbortError` that `abort()` produces.
+   */
+  timeout?: number
+}
+
 export class FetchHttpStack implements HttpStack {
+  private _timeout?: number
+
+  constructor({ timeout }: FetchHttpStackOptions = {}) {
+    this._timeout = timeout
+  }
+
   createRequest(method: string, url: string) {
-    return new FetchRequest(method, url)
+    return new FetchRequest(method, url, this._timeout)
   }
 
   getName() {
@@ -23,10 +40,12 @@ class FetchRequest implements HttpRequest {
   private _url: string
   private _headers: Record<string, string> = {}
   private _controller = new AbortController()
+  private _timeout?: number
 
-  constructor(method: string, url: string) {
+  constructor(method: string, url: string, timeout?: number) {
     this._method = method
     this._url = url
+    this._timeout = timeout
   }
 
   getMethod(): string {
@@ -56,15 +75,33 @@ class FetchRequest implements HttpRequest {
       )
     }
 
-    const res = await fetch(this._url, {
-      method: this._method,
-      headers: this._headers,
-      body,
-      signal: this._controller.signal,
-    })
+    const deadline = this._startDeadline()
 
-    const resBody = await res.text()
-    return new FetchResponse(res, resBody)
+    try {
+      const res = await fetch(this._url, {
+        method: this._method,
+        headers: this._headers,
+        body,
+        signal: this._controller.signal,
+      })
+
+      const resBody = await res.text()
+      return new FetchResponse(res, resBody)
+    } finally {
+      // Always cleared: a deadline that outlives its request would abort a
+      // signal with nothing behind it, and keep a timer alive with it.
+      clearTimeout(deadline)
+    }
+  }
+
+  private _startDeadline(): ReturnType<typeof setTimeout> | undefined {
+    if (this._timeout == null) {
+      return undefined
+    }
+
+    return setTimeout(() => {
+      this._controller.abort(new DOMException('Request timed out', 'TimeoutError'))
+    }, this._timeout)
   }
 
   abort(): Promise<void> {

--- a/lib/browser/urlStorage.ts
+++ b/lib/browser/urlStorage.ts
@@ -2,17 +2,24 @@ import type { PreviousUpload, UrlStorage } from '../options.js'
 
 let hasStorage = false
 try {
-  // Note: localStorage does not exist in the Web Worker's context, so we must use window here.
-  hasStorage = 'localStorage' in window
+  // Note: `window` is absent in a Web Worker and a Service Worker, and a bare
+  // reference to it throws a ReferenceError rather than a DOMException, so it
+  // would escape the catch below and take this module -- and with it the whole
+  // browser entry point -- down on import. `typeof` covers both realms: it is
+  // false where there is no storage, and still throws the SecurityError that a
+  // sandboxed iframe raises from the getter.
+  hasStorage = typeof localStorage !== 'undefined'
 
-  // Attempt to store and read entries from the local storage to detect Private
-  // Mode on Safari on iOS (see #49)
-  // If the key was not used before, we remove it from local storage again to
-  // not cause confusion where the entry came from.
-  const key = 'tusSupport'
-  const originalValue = localStorage.getItem(key)
-  localStorage.setItem(key, String(originalValue))
-  if (originalValue == null) localStorage.removeItem(key)
+  if (hasStorage) {
+    // Attempt to store and read entries from the local storage to detect Private
+    // Mode on Safari on iOS (see #49)
+    // If the key was not used before, we remove it from local storage again to
+    // not cause confusion where the entry came from.
+    const key = 'tusSupport'
+    const originalValue = localStorage.getItem(key)
+    localStorage.setItem(key, String(originalValue))
+    if (originalValue == null) localStorage.removeItem(key)
+  }
 } catch (e: unknown) {
   // If we try to access localStorage inside a sandboxed iframe, a SecurityError
   // is thrown. When in private mode on iOS Safari, a QuotaExceededError is

--- a/test/spec/browser-index.js
+++ b/test/spec/browser-index.js
@@ -6,6 +6,7 @@ beforeEach(() => {
 
 import './test-common.js'
 import './test-browser-specific.js'
+import './test-fetch-http-stack.js'
 import './test-parallel-uploads.js'
 import './test-terminate.js'
 import './test-web-stream.js'

--- a/test/spec/node-index.js
+++ b/test/spec/node-index.js
@@ -1,5 +1,6 @@
 import './test-common.js'
 import './test-node-specific.js'
+import './test-no-dom-globals.js'
 import './test-parallel-uploads.js'
 import './test-terminate.js'
 import './test-web-stream.js'

--- a/test/spec/test-fetch-http-stack.js
+++ b/test/spec/test-fetch-http-stack.js
@@ -1,0 +1,100 @@
+import { FetchHttpStack } from 'tus-js-client/browser/FetchHttpStack'
+
+// A fetch stub that never settles on its own, but honours the abort signal the
+// same way the real Fetch API does. Needed to exercise FetchRequest#abort.
+function hangingFetch(_url, options) {
+  return new Promise((_resolve, reject) => {
+    options.signal.addEventListener('abort', () => {
+      reject(new DOMException('The operation was aborted.', 'AbortError'))
+    })
+  })
+}
+
+describe('tus.FetchHttpStack', () => {
+  it('should report its name', () => {
+    expect(new FetchHttpStack().getName()).toBe('FetchHttpStack')
+  })
+
+  it('should expose the method and URL it was created with', () => {
+    const req = new FetchHttpStack().createRequest('PATCH', 'http://tus.io/uploads/foo')
+
+    expect(req.getMethod()).toBe('PATCH')
+    expect(req.getURL()).toBe('http://tus.io/uploads/foo')
+  })
+
+  it('should store and return headers', () => {
+    const req = new FetchHttpStack().createRequest('POST', 'http://tus.io/uploads')
+
+    req.setHeader('Tus-Resumable', '1.0.0')
+
+    expect(req.getHeader('Tus-Resumable')).toBe('1.0.0')
+    expect(req.getHeader('Upload-Offset')).toBe(undefined)
+  })
+
+  it('should send the method, URL, headers and body to fetch', async () => {
+    spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 204 }))
+
+    const req = new FetchHttpStack().createRequest('PATCH', 'http://tus.io/uploads/foo')
+    req.setHeader('Upload-Offset', '0')
+    const body = new Blob(['hello world'])
+    await req.send(body)
+
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+    const [url, options] = window.fetch.calls.mostRecent().args
+    expect(url).toBe('http://tus.io/uploads/foo')
+    expect(options.method).toBe('PATCH')
+    expect(options.headers).toEqual({ 'Upload-Offset': '0' })
+    expect(options.body).toBe(body)
+  })
+
+  it('should resolve a response exposing status, headers and body', async () => {
+    const response = new Response('hello world', {
+      status: 200,
+      headers: { 'Upload-Offset': '11' },
+    })
+    spyOn(window, 'fetch').and.resolveTo(response)
+
+    const res = await new FetchHttpStack().createRequest('GET', 'http://tus.io/uploads/foo').send()
+
+    expect(res.getStatus()).toBe(200)
+    expect(res.getHeader('Upload-Offset')).toBe('11')
+    expect(res.getBody()).toBe('hello world')
+    expect(res.getUnderlyingObject()).toBe(response)
+  })
+
+  it('should return undefined for a missing response header', async () => {
+    spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 204 }))
+
+    const res = await new FetchHttpStack().createRequest('HEAD', 'http://tus.io/uploads/foo').send()
+
+    expect(res.getHeader('Upload-Offset')).toBe(undefined)
+  })
+
+  it('should have no underlying request object', () => {
+    const req = new FetchHttpStack().createRequest('POST', 'http://tus.io/uploads')
+
+    expect(req.getUnderlyingObject()).toBe(undefined)
+  })
+
+  it('should accept a progress handler without reporting progress', async () => {
+    spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 204 }))
+    const onProgress = jasmine.createSpy('onProgress')
+
+    const req = new FetchHttpStack().createRequest('PATCH', 'http://tus.io/uploads/foo')
+    req.setProgressHandler(onProgress)
+    await req.send(new Blob(['hello world']))
+
+    // The Fetch API exposes no upload progress, so the handler is never invoked.
+    expect(onProgress).not.toHaveBeenCalled()
+  })
+
+  it('should reject with an AbortError when aborted', async () => {
+    spyOn(window, 'fetch').and.callFake(hangingFetch)
+
+    const req = new FetchHttpStack().createRequest('PATCH', 'http://tus.io/uploads/foo')
+    const sending = req.send(new Blob(['hello world']))
+    await req.abort()
+
+    await expectAsync(sending).toBeRejectedWithError(DOMException, /aborted/)
+  })
+})

--- a/test/spec/test-fetch-http-stack.js
+++ b/test/spec/test-fetch-http-stack.js
@@ -1,11 +1,14 @@
 import { FetchHttpStack } from 'tus-js-client/browser/FetchHttpStack'
+import { wait } from './helpers/utils.js'
 
 // A fetch stub that never settles on its own, but honours the abort signal the
 // same way the real Fetch API does. Needed to exercise FetchRequest#abort.
 function hangingFetch(_url, options) {
   return new Promise((_resolve, reject) => {
     options.signal.addEventListener('abort', () => {
-      reject(new DOMException('The operation was aborted.', 'AbortError'))
+      // Real fetch rejects with the signal's reason, which is an AbortError
+      // DOMException unless abort() was given one.
+      reject(options.signal.reason)
     })
   })
 }
@@ -96,5 +99,68 @@ describe('tus.FetchHttpStack', () => {
     await req.abort()
 
     await expectAsync(sending).toBeRejectedWithError(DOMException, /aborted/)
+  })
+})
+
+describe('tus.FetchHttpStack with a timeout', () => {
+  it('should reject with a TimeoutError once the timeout elapses', async () => {
+    spyOn(window, 'fetch').and.callFake(hangingFetch)
+
+    const req = new FetchHttpStack({ timeout: 50 }).createRequest(
+      'PATCH',
+      'http://tus.io/uploads/foo',
+    )
+
+    await expectAsync(req.send(new Blob(['hello world']))).toBeRejectedWithError(
+      DOMException,
+      /timed out/,
+    )
+  })
+
+  it('should distinguish a timeout from a caller-initiated abort', async () => {
+    spyOn(window, 'fetch').and.callFake(hangingFetch)
+
+    const req = new FetchHttpStack({ timeout: 50 }).createRequest(
+      'PATCH',
+      'http://tus.io/uploads/foo',
+    )
+    const sending = req.send(new Blob(['hello world']))
+    await req.abort()
+
+    await expectAsync(sending).toBeRejectedWithError(DOMException, /aborted/)
+  })
+
+  it('should not abort a request that completes within the timeout', async () => {
+    spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 204 }))
+
+    const req = new FetchHttpStack({ timeout: 50 }).createRequest(
+      'PATCH',
+      'http://tus.io/uploads/foo',
+    )
+    const res = await req.send(new Blob(['hello world']))
+    const { signal } = window.fetch.calls.mostRecent().args[1]
+
+    expect(res.getStatus()).toBe(204)
+
+    // The deadline must be cleared once the request settles, or it fires against
+    // a signal that no longer has a request behind it.
+    await wait(100)
+    expect(signal.aborted).toBe(false)
+  })
+
+  it('should not time out when no timeout is configured', async () => {
+    spyOn(window, 'fetch').and.callFake(hangingFetch)
+
+    const req = new FetchHttpStack().createRequest('PATCH', 'http://tus.io/uploads/foo')
+    const sending = req.send(new Blob(['hello world']))
+
+    const outcome = await Promise.race([
+      sending.then(
+        () => 'settled',
+        () => 'rejected',
+      ),
+      wait(100),
+    ])
+    expect(outcome).toBe('timed out')
   })
 })

--- a/test/spec/test-no-dom-globals.js
+++ b/test/spec/test-no-dom-globals.js
@@ -1,17 +1,18 @@
-// A service worker has no `window` and no `localStorage`. Node has neither
-// either, which makes the Node suite the place to prove that the browser's URL
-// storage can be loaded outside a document at all.
+// `lib/browser/urlStorage.ts` runs its feature detection at module scope, so a throw
+// there takes down the browser entry point on import, and with it any hope of using
+// tus-js-client in a Service Worker. This proves the module survives the absence of
+// `window`, which is the condition that used to throw.
 //
-// This module is imported by the browser entry point and runs its feature
-// detection at module scope, so a throw here takes down the whole entry point
-// and with it any hope of using tus-js-client in a service worker.
+// Node and Deno both lack `window`, and they disagree about `localStorage` -- Deno
+// implements Web Storage, Node does not. So what is asserted is that the module LOADS
+// and reports the runtime it actually found, rather than a fixed answer that would
+// only hold on one of them.
 describe('browser urlStorage without DOM globals', () => {
   it('should load where window does not exist', async () => {
     expect(typeof window).toBe('undefined')
-    expect(typeof localStorage).toBe('undefined')
 
     const { canStoreURLs } = await import('../../lib.esm/browser/urlStorage.js')
 
-    expect(canStoreURLs).toBe(false)
+    expect(canStoreURLs).toBe(typeof localStorage !== 'undefined')
   })
 })

--- a/test/spec/test-no-dom-globals.js
+++ b/test/spec/test-no-dom-globals.js
@@ -1,0 +1,17 @@
+// A service worker has no `window` and no `localStorage`. Node has neither
+// either, which makes the Node suite the place to prove that the browser's URL
+// storage can be loaded outside a document at all.
+//
+// This module is imported by the browser entry point and runs its feature
+// detection at module scope, so a throw here takes down the whole entry point
+// and with it any hope of using tus-js-client in a service worker.
+describe('browser urlStorage without DOM globals', () => {
+  it('should load where window does not exist', async () => {
+    expect(typeof window).toBe('undefined')
+    expect(typeof localStorage).toBe('undefined')
+
+    const { canStoreURLs } = await import('../../lib.esm/browser/urlStorage.js')
+
+    expect(canStoreURLs).toBe(false)
+  })
+})


### PR DESCRIPTION
Motivation

We upload proof-of-placement photos from a PWA used by contractors on weak or absent mobile networks, iOS Safari being the primary target. The page captures a photo into IndexedDB and a Service Worker drains the queue, so an upload survives the page being closed and can be woken by Background Sync.

That architecture is what pushed us to tus: a Service Worker has no XMLHttpRequest, so upload.onprogress does not exist there, and a connection dropped mid-upload restarts from zero. Chunked, resumable uploads answer both — with a finite chunkSize, chunk completion is the progress signal, so the absence of upload-progress events stops mattering.

We could not use tus-js-client in that context. This PR is the set of changes that made it work.

The constraint: the library cannot currently load in a Service Worker

Not "does not report progress" — does not load at all.

import { Upload } from 'tus-js-client'
// ReferenceError: window is not defined

lib/browser/urlStorage.ts runs its feature detection at module scope:

hasStorage = 'localStorage' in window

A Service Worker (and a Web Worker) has no window, so this throws a ReferenceError. The surrounding catch only converts DOMException — the SecurityError from a sandboxed iframe and the QuotaExceededError from iOS private mode — and rethrows everything else. So the ReferenceError escapes, and because lib/browser/index.ts imports this module, the throw takes down the entire browser entry point on import.

The comment above the line explains the intent:

// Note: localStorage does not exist in the Web Worker's context, so we must use window here.

The premise is right and the conclusion is inverted: window does not exist in a worker either, which is exactly what makes the line throw. This affects both the 4.x line and 5.0.0-pre2.

Reproduced with a bundle evaluated with self defined and window absent, which is what a Service Worker global scope looks like:

before: ReferenceError: window is not defined
after:  loads

What is in this PR

1. Fix urlStorage throwing on import outside a document

typeof localStorage !== 'undefined' instead of 'localStorage' in window. It is false where there is no storage, and it still surfaces the SecurityError that a sandboxed iframe raises from the property getter, so the private-mode and iframe handling below is unchanged. The storage probe becomes conditional, since it cannot run where there is no storage.

Regression test lives in the Node suite, which is the one environment in the project where window is genuinely absent. It imports lib.esm/browser/urlStorage.js directly and asserts canStoreURLs === false.

▎ Importing the whole browser entry point in Node would be the better test, but it hits an unrelated wall first: is-stream@2 is CJS and Node's native ESM cannot take a named readable import from it. Bundlers handle that interop, so it only affects a raw Node import. Happy to widen the test if you would rather solve that too.

2. Add tests for FetchHttpStack

FetchHttpStack shipped with // TODO: Add tests for this. and no coverage. Nine specs covering the HttpStack / HttpRequest / HttpResponse contract: name, method and URL accessors, header round-tripping, what reaches fetch(), the status, headers and body it exposes back, the absent underlying request object, the documented no-op progress handler, and abort() rejecting the send.

The stub rejects with signal.reason rather than a fabricated AbortError, matching what the real Fetch API does — which is what lets the timeout test below distinguish the two.

3. Add an optional timeout to FetchHttpStack

The Fetch API has no timeout of its own, so a request that stalls without erroring is never resolved nor rejected. A custom XHRHttpStack caller can reach for XMLHttpRequest.timeout; a FetchHttpStack caller had nothing, and there is no timeout in UploadOptions either.

This matters most in the environment FetchHttpStack exists to serve. In a Service Worker there is no page to notice a hung PATCH, so the upload simply strands.

new FetchHttpStack({ timeout: 30000 })

It aborts with a TimeoutError DOMException rather than the default AbortError, so a caller can tell a deadline from an abort() it asked for and decide whether the attempt is worth retrying. Defaults to no timeout, so existing behaviour is unchanged.

Also documents FetchHttpStack in docs/api.md, which covered the HttpStack interface but never the fetch implementation of it — including the two things that surprise people: setProgressHandler is a no-op, so chunkSize is what determines progress granularity, and Node readable streams are not supported as a body.

Testing

- Browser (karma/puppeteer): 81 specs, green
- Node (jasmine): 80 specs, green

One note in case it saves someone time: the Chromium that puppeteer.executablePath() resolves to was a stale x86 build on an arm64 machine, and karma fails with Cannot start ChromeHeadless. Setting CHROME_BIN to a system Chrome works.

Open questions for maintainers

1. isSupported still requires XMLHttpRequest. With FetchHttpStack the library now works where XMLHttpRequest does not exist, so isSupported reports false in a Service Worker despite the library being usable there. I left the semantics alone rather than change them unilaterally. Would you like it widened, or a separate export?

2. Default httpStack in worker contexts. lib/browser/index.ts still defaults to XHRHttpStack, so worker callers must pass httpStack explicitly. That seems right to me — it keeps the default path unchanged for every existing consumer — but an environment-sensitive default is an option if you would prefer one.

3. Should the timeout live on UploadOptions instead? A stack-level option was the smaller change, but a timeout that every stack honours may be the better shape. Happy to move it.